### PR TITLE
Fix missing `__extenddftf2` symbols for x86-64 targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,6 @@ correct ipv4 address and port number via an environment variable or the command 
 flutter run --dart-define=RELAY_ADDRESS=203.0.113.0:2022
 ```
 
-As of the time of writing this functionality is not supported by emulated devices. We recommend only
-enabling when running on hardware devices.
-
 ### Schema
 
 The p2panda schemas and migrations are managed in the `schemas` folder with the

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ providing all p2panda functionality via FFI bindings.
 > Listed versions are the ones we used successfully in our developer
 > environments, other versions might work well too.
 
-* [Rust](https://www.rust-lang.org/tools/install) `1.70.0`
+* [Rust](https://www.rust-lang.org/tools/install) `1.73.0`
 * [Android SDK](https://developer.android.com/tools) `34.0.0`
 * [Android NDK](https://developer.android.com/ndk/) `25.2.9519653`
-* [Flutter SDK](https://docs.flutter.dev/get-started/install) `3.10.5` and Dart SDK `3.0.5`
+* [Flutter SDK](https://docs.flutter.dev/get-started/install) `3.13.7` and Dart SDK `3.1.3`
 * [Melos](https://melos.invertase.dev/getting-started)
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ providing all p2panda functionality via FFI bindings.
 ### Requirements
 
 > Listed versions are the ones we used successfully in our developer
-> environments, other versions might work well too.
+> environments, other versions might work well too, the exact NDK version is
+> _required_ though.
 
 * [Rust](https://www.rust-lang.org/tools/install) `1.73.0`
 * [Android SDK](https://developer.android.com/tools) `34.0.0`

--- a/packages/app/android/app/build.gradle
+++ b/packages/app/android/app/build.gradle
@@ -29,7 +29,9 @@ android {
     namespace "com.p2panda.app"
     // Set to mimimum version 33 for `geolocator` package
     compileSdkVersion Math.max(flutter.compileSdkVersion, 33)
-    ndkVersion flutter.ndkVersion
+    // Pin NDK version to assure compatibility with cargo-ndk build (see
+    // "packages/p2panda/native/build.rs" file for details)
+    ndkVersion "25.2.9519653"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/p2panda/lib/src/bridge_generated.freezed.dart
+++ b/packages/p2panda/lib/src/bridge_generated.freezed.dart
@@ -122,22 +122,20 @@ class _$OperationValueCopyWithImpl<$Res, $Val extends OperationValue>
 }
 
 /// @nodoc
-abstract class _$$OperationValue_BooleanImplCopyWith<$Res> {
-  factory _$$OperationValue_BooleanImplCopyWith(
-          _$OperationValue_BooleanImpl value,
-          $Res Function(_$OperationValue_BooleanImpl) then) =
-      __$$OperationValue_BooleanImplCopyWithImpl<$Res>;
+abstract class _$$OperationValue_BooleanCopyWith<$Res> {
+  factory _$$OperationValue_BooleanCopyWith(_$OperationValue_Boolean value,
+          $Res Function(_$OperationValue_Boolean) then) =
+      __$$OperationValue_BooleanCopyWithImpl<$Res>;
   @useResult
   $Res call({bool field0});
 }
 
 /// @nodoc
-class __$$OperationValue_BooleanImplCopyWithImpl<$Res>
-    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_BooleanImpl>
-    implements _$$OperationValue_BooleanImplCopyWith<$Res> {
-  __$$OperationValue_BooleanImplCopyWithImpl(
-      _$OperationValue_BooleanImpl _value,
-      $Res Function(_$OperationValue_BooleanImpl) _then)
+class __$$OperationValue_BooleanCopyWithImpl<$Res>
+    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_Boolean>
+    implements _$$OperationValue_BooleanCopyWith<$Res> {
+  __$$OperationValue_BooleanCopyWithImpl(_$OperationValue_Boolean _value,
+      $Res Function(_$OperationValue_Boolean) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -145,7 +143,7 @@ class __$$OperationValue_BooleanImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$OperationValue_BooleanImpl(
+    return _then(_$OperationValue_Boolean(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -156,8 +154,8 @@ class __$$OperationValue_BooleanImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$OperationValue_BooleanImpl implements OperationValue_Boolean {
-  const _$OperationValue_BooleanImpl(this.field0);
+class _$OperationValue_Boolean implements OperationValue_Boolean {
+  const _$OperationValue_Boolean(this.field0);
 
   @override
   final bool field0;
@@ -171,7 +169,7 @@ class _$OperationValue_BooleanImpl implements OperationValue_Boolean {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$OperationValue_BooleanImpl &&
+            other is _$OperationValue_Boolean &&
             (identical(other.field0, field0) || other.field0 == field0));
   }
 
@@ -181,9 +179,9 @@ class _$OperationValue_BooleanImpl implements OperationValue_Boolean {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$OperationValue_BooleanImplCopyWith<_$OperationValue_BooleanImpl>
-      get copyWith => __$$OperationValue_BooleanImplCopyWithImpl<
-          _$OperationValue_BooleanImpl>(this, _$identity);
+  _$$OperationValue_BooleanCopyWith<_$OperationValue_Boolean> get copyWith =>
+      __$$OperationValue_BooleanCopyWithImpl<_$OperationValue_Boolean>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -296,30 +294,30 @@ class _$OperationValue_BooleanImpl implements OperationValue_Boolean {
 
 abstract class OperationValue_Boolean implements OperationValue {
   const factory OperationValue_Boolean(final bool field0) =
-      _$OperationValue_BooleanImpl;
+      _$OperationValue_Boolean;
 
   @override
   bool get field0;
   @JsonKey(ignore: true)
-  _$$OperationValue_BooleanImplCopyWith<_$OperationValue_BooleanImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$OperationValue_BooleanCopyWith<_$OperationValue_Boolean> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$OperationValue_FloatImplCopyWith<$Res> {
-  factory _$$OperationValue_FloatImplCopyWith(_$OperationValue_FloatImpl value,
-          $Res Function(_$OperationValue_FloatImpl) then) =
-      __$$OperationValue_FloatImplCopyWithImpl<$Res>;
+abstract class _$$OperationValue_FloatCopyWith<$Res> {
+  factory _$$OperationValue_FloatCopyWith(_$OperationValue_Float value,
+          $Res Function(_$OperationValue_Float) then) =
+      __$$OperationValue_FloatCopyWithImpl<$Res>;
   @useResult
   $Res call({double field0});
 }
 
 /// @nodoc
-class __$$OperationValue_FloatImplCopyWithImpl<$Res>
-    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_FloatImpl>
-    implements _$$OperationValue_FloatImplCopyWith<$Res> {
-  __$$OperationValue_FloatImplCopyWithImpl(_$OperationValue_FloatImpl _value,
-      $Res Function(_$OperationValue_FloatImpl) _then)
+class __$$OperationValue_FloatCopyWithImpl<$Res>
+    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_Float>
+    implements _$$OperationValue_FloatCopyWith<$Res> {
+  __$$OperationValue_FloatCopyWithImpl(_$OperationValue_Float _value,
+      $Res Function(_$OperationValue_Float) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -327,7 +325,7 @@ class __$$OperationValue_FloatImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$OperationValue_FloatImpl(
+    return _then(_$OperationValue_Float(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -338,8 +336,8 @@ class __$$OperationValue_FloatImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$OperationValue_FloatImpl implements OperationValue_Float {
-  const _$OperationValue_FloatImpl(this.field0);
+class _$OperationValue_Float implements OperationValue_Float {
+  const _$OperationValue_Float(this.field0);
 
   @override
   final double field0;
@@ -353,7 +351,7 @@ class _$OperationValue_FloatImpl implements OperationValue_Float {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$OperationValue_FloatImpl &&
+            other is _$OperationValue_Float &&
             (identical(other.field0, field0) || other.field0 == field0));
   }
 
@@ -363,10 +361,9 @@ class _$OperationValue_FloatImpl implements OperationValue_Float {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$OperationValue_FloatImplCopyWith<_$OperationValue_FloatImpl>
-      get copyWith =>
-          __$$OperationValue_FloatImplCopyWithImpl<_$OperationValue_FloatImpl>(
-              this, _$identity);
+  _$$OperationValue_FloatCopyWith<_$OperationValue_Float> get copyWith =>
+      __$$OperationValue_FloatCopyWithImpl<_$OperationValue_Float>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -479,32 +476,30 @@ class _$OperationValue_FloatImpl implements OperationValue_Float {
 
 abstract class OperationValue_Float implements OperationValue {
   const factory OperationValue_Float(final double field0) =
-      _$OperationValue_FloatImpl;
+      _$OperationValue_Float;
 
   @override
   double get field0;
   @JsonKey(ignore: true)
-  _$$OperationValue_FloatImplCopyWith<_$OperationValue_FloatImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$OperationValue_FloatCopyWith<_$OperationValue_Float> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$OperationValue_IntegerImplCopyWith<$Res> {
-  factory _$$OperationValue_IntegerImplCopyWith(
-          _$OperationValue_IntegerImpl value,
-          $Res Function(_$OperationValue_IntegerImpl) then) =
-      __$$OperationValue_IntegerImplCopyWithImpl<$Res>;
+abstract class _$$OperationValue_IntegerCopyWith<$Res> {
+  factory _$$OperationValue_IntegerCopyWith(_$OperationValue_Integer value,
+          $Res Function(_$OperationValue_Integer) then) =
+      __$$OperationValue_IntegerCopyWithImpl<$Res>;
   @useResult
   $Res call({int field0});
 }
 
 /// @nodoc
-class __$$OperationValue_IntegerImplCopyWithImpl<$Res>
-    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_IntegerImpl>
-    implements _$$OperationValue_IntegerImplCopyWith<$Res> {
-  __$$OperationValue_IntegerImplCopyWithImpl(
-      _$OperationValue_IntegerImpl _value,
-      $Res Function(_$OperationValue_IntegerImpl) _then)
+class __$$OperationValue_IntegerCopyWithImpl<$Res>
+    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_Integer>
+    implements _$$OperationValue_IntegerCopyWith<$Res> {
+  __$$OperationValue_IntegerCopyWithImpl(_$OperationValue_Integer _value,
+      $Res Function(_$OperationValue_Integer) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -512,7 +507,7 @@ class __$$OperationValue_IntegerImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$OperationValue_IntegerImpl(
+    return _then(_$OperationValue_Integer(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -523,8 +518,8 @@ class __$$OperationValue_IntegerImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$OperationValue_IntegerImpl implements OperationValue_Integer {
-  const _$OperationValue_IntegerImpl(this.field0);
+class _$OperationValue_Integer implements OperationValue_Integer {
+  const _$OperationValue_Integer(this.field0);
 
   @override
   final int field0;
@@ -538,7 +533,7 @@ class _$OperationValue_IntegerImpl implements OperationValue_Integer {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$OperationValue_IntegerImpl &&
+            other is _$OperationValue_Integer &&
             (identical(other.field0, field0) || other.field0 == field0));
   }
 
@@ -548,9 +543,9 @@ class _$OperationValue_IntegerImpl implements OperationValue_Integer {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$OperationValue_IntegerImplCopyWith<_$OperationValue_IntegerImpl>
-      get copyWith => __$$OperationValue_IntegerImplCopyWithImpl<
-          _$OperationValue_IntegerImpl>(this, _$identity);
+  _$$OperationValue_IntegerCopyWith<_$OperationValue_Integer> get copyWith =>
+      __$$OperationValue_IntegerCopyWithImpl<_$OperationValue_Integer>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -663,31 +658,30 @@ class _$OperationValue_IntegerImpl implements OperationValue_Integer {
 
 abstract class OperationValue_Integer implements OperationValue {
   const factory OperationValue_Integer(final int field0) =
-      _$OperationValue_IntegerImpl;
+      _$OperationValue_Integer;
 
   @override
   int get field0;
   @JsonKey(ignore: true)
-  _$$OperationValue_IntegerImplCopyWith<_$OperationValue_IntegerImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$OperationValue_IntegerCopyWith<_$OperationValue_Integer> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$OperationValue_StringImplCopyWith<$Res> {
-  factory _$$OperationValue_StringImplCopyWith(
-          _$OperationValue_StringImpl value,
-          $Res Function(_$OperationValue_StringImpl) then) =
-      __$$OperationValue_StringImplCopyWithImpl<$Res>;
+abstract class _$$OperationValue_StringCopyWith<$Res> {
+  factory _$$OperationValue_StringCopyWith(_$OperationValue_String value,
+          $Res Function(_$OperationValue_String) then) =
+      __$$OperationValue_StringCopyWithImpl<$Res>;
   @useResult
   $Res call({String field0});
 }
 
 /// @nodoc
-class __$$OperationValue_StringImplCopyWithImpl<$Res>
-    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_StringImpl>
-    implements _$$OperationValue_StringImplCopyWith<$Res> {
-  __$$OperationValue_StringImplCopyWithImpl(_$OperationValue_StringImpl _value,
-      $Res Function(_$OperationValue_StringImpl) _then)
+class __$$OperationValue_StringCopyWithImpl<$Res>
+    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_String>
+    implements _$$OperationValue_StringCopyWith<$Res> {
+  __$$OperationValue_StringCopyWithImpl(_$OperationValue_String _value,
+      $Res Function(_$OperationValue_String) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -695,7 +689,7 @@ class __$$OperationValue_StringImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$OperationValue_StringImpl(
+    return _then(_$OperationValue_String(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -706,8 +700,8 @@ class __$$OperationValue_StringImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$OperationValue_StringImpl implements OperationValue_String {
-  const _$OperationValue_StringImpl(this.field0);
+class _$OperationValue_String implements OperationValue_String {
+  const _$OperationValue_String(this.field0);
 
   @override
   final String field0;
@@ -721,7 +715,7 @@ class _$OperationValue_StringImpl implements OperationValue_String {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$OperationValue_StringImpl &&
+            other is _$OperationValue_String &&
             (identical(other.field0, field0) || other.field0 == field0));
   }
 
@@ -731,9 +725,9 @@ class _$OperationValue_StringImpl implements OperationValue_String {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$OperationValue_StringImplCopyWith<_$OperationValue_StringImpl>
-      get copyWith => __$$OperationValue_StringImplCopyWithImpl<
-          _$OperationValue_StringImpl>(this, _$identity);
+  _$$OperationValue_StringCopyWith<_$OperationValue_String> get copyWith =>
+      __$$OperationValue_StringCopyWithImpl<_$OperationValue_String>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -846,30 +840,30 @@ class _$OperationValue_StringImpl implements OperationValue_String {
 
 abstract class OperationValue_String implements OperationValue {
   const factory OperationValue_String(final String field0) =
-      _$OperationValue_StringImpl;
+      _$OperationValue_String;
 
   @override
   String get field0;
   @JsonKey(ignore: true)
-  _$$OperationValue_StringImplCopyWith<_$OperationValue_StringImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$OperationValue_StringCopyWith<_$OperationValue_String> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$OperationValue_BytesImplCopyWith<$Res> {
-  factory _$$OperationValue_BytesImplCopyWith(_$OperationValue_BytesImpl value,
-          $Res Function(_$OperationValue_BytesImpl) then) =
-      __$$OperationValue_BytesImplCopyWithImpl<$Res>;
+abstract class _$$OperationValue_BytesCopyWith<$Res> {
+  factory _$$OperationValue_BytesCopyWith(_$OperationValue_Bytes value,
+          $Res Function(_$OperationValue_Bytes) then) =
+      __$$OperationValue_BytesCopyWithImpl<$Res>;
   @useResult
   $Res call({Uint8List field0});
 }
 
 /// @nodoc
-class __$$OperationValue_BytesImplCopyWithImpl<$Res>
-    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_BytesImpl>
-    implements _$$OperationValue_BytesImplCopyWith<$Res> {
-  __$$OperationValue_BytesImplCopyWithImpl(_$OperationValue_BytesImpl _value,
-      $Res Function(_$OperationValue_BytesImpl) _then)
+class __$$OperationValue_BytesCopyWithImpl<$Res>
+    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_Bytes>
+    implements _$$OperationValue_BytesCopyWith<$Res> {
+  __$$OperationValue_BytesCopyWithImpl(_$OperationValue_Bytes _value,
+      $Res Function(_$OperationValue_Bytes) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -877,7 +871,7 @@ class __$$OperationValue_BytesImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$OperationValue_BytesImpl(
+    return _then(_$OperationValue_Bytes(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -888,8 +882,8 @@ class __$$OperationValue_BytesImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$OperationValue_BytesImpl implements OperationValue_Bytes {
-  const _$OperationValue_BytesImpl(this.field0);
+class _$OperationValue_Bytes implements OperationValue_Bytes {
+  const _$OperationValue_Bytes(this.field0);
 
   @override
   final Uint8List field0;
@@ -903,7 +897,7 @@ class _$OperationValue_BytesImpl implements OperationValue_Bytes {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$OperationValue_BytesImpl &&
+            other is _$OperationValue_Bytes &&
             const DeepCollectionEquality().equals(other.field0, field0));
   }
 
@@ -914,10 +908,9 @@ class _$OperationValue_BytesImpl implements OperationValue_Bytes {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$OperationValue_BytesImplCopyWith<_$OperationValue_BytesImpl>
-      get copyWith =>
-          __$$OperationValue_BytesImplCopyWithImpl<_$OperationValue_BytesImpl>(
-              this, _$identity);
+  _$$OperationValue_BytesCopyWith<_$OperationValue_Bytes> get copyWith =>
+      __$$OperationValue_BytesCopyWithImpl<_$OperationValue_Bytes>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1030,32 +1023,30 @@ class _$OperationValue_BytesImpl implements OperationValue_Bytes {
 
 abstract class OperationValue_Bytes implements OperationValue {
   const factory OperationValue_Bytes(final Uint8List field0) =
-      _$OperationValue_BytesImpl;
+      _$OperationValue_Bytes;
 
   @override
   Uint8List get field0;
   @JsonKey(ignore: true)
-  _$$OperationValue_BytesImplCopyWith<_$OperationValue_BytesImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$OperationValue_BytesCopyWith<_$OperationValue_Bytes> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$OperationValue_RelationImplCopyWith<$Res> {
-  factory _$$OperationValue_RelationImplCopyWith(
-          _$OperationValue_RelationImpl value,
-          $Res Function(_$OperationValue_RelationImpl) then) =
-      __$$OperationValue_RelationImplCopyWithImpl<$Res>;
+abstract class _$$OperationValue_RelationCopyWith<$Res> {
+  factory _$$OperationValue_RelationCopyWith(_$OperationValue_Relation value,
+          $Res Function(_$OperationValue_Relation) then) =
+      __$$OperationValue_RelationCopyWithImpl<$Res>;
   @useResult
   $Res call({String field0});
 }
 
 /// @nodoc
-class __$$OperationValue_RelationImplCopyWithImpl<$Res>
-    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_RelationImpl>
-    implements _$$OperationValue_RelationImplCopyWith<$Res> {
-  __$$OperationValue_RelationImplCopyWithImpl(
-      _$OperationValue_RelationImpl _value,
-      $Res Function(_$OperationValue_RelationImpl) _then)
+class __$$OperationValue_RelationCopyWithImpl<$Res>
+    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_Relation>
+    implements _$$OperationValue_RelationCopyWith<$Res> {
+  __$$OperationValue_RelationCopyWithImpl(_$OperationValue_Relation _value,
+      $Res Function(_$OperationValue_Relation) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1063,7 +1054,7 @@ class __$$OperationValue_RelationImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$OperationValue_RelationImpl(
+    return _then(_$OperationValue_Relation(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -1074,8 +1065,8 @@ class __$$OperationValue_RelationImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$OperationValue_RelationImpl implements OperationValue_Relation {
-  const _$OperationValue_RelationImpl(this.field0);
+class _$OperationValue_Relation implements OperationValue_Relation {
+  const _$OperationValue_Relation(this.field0);
 
   @override
   final String field0;
@@ -1089,7 +1080,7 @@ class _$OperationValue_RelationImpl implements OperationValue_Relation {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$OperationValue_RelationImpl &&
+            other is _$OperationValue_Relation &&
             (identical(other.field0, field0) || other.field0 == field0));
   }
 
@@ -1099,9 +1090,9 @@ class _$OperationValue_RelationImpl implements OperationValue_Relation {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$OperationValue_RelationImplCopyWith<_$OperationValue_RelationImpl>
-      get copyWith => __$$OperationValue_RelationImplCopyWithImpl<
-          _$OperationValue_RelationImpl>(this, _$identity);
+  _$$OperationValue_RelationCopyWith<_$OperationValue_Relation> get copyWith =>
+      __$$OperationValue_RelationCopyWithImpl<_$OperationValue_Relation>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1214,33 +1205,32 @@ class _$OperationValue_RelationImpl implements OperationValue_Relation {
 
 abstract class OperationValue_Relation implements OperationValue {
   const factory OperationValue_Relation(final String field0) =
-      _$OperationValue_RelationImpl;
+      _$OperationValue_Relation;
 
   @override
   String get field0;
   @JsonKey(ignore: true)
-  _$$OperationValue_RelationImplCopyWith<_$OperationValue_RelationImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$OperationValue_RelationCopyWith<_$OperationValue_Relation> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$OperationValue_RelationListImplCopyWith<$Res> {
-  factory _$$OperationValue_RelationListImplCopyWith(
-          _$OperationValue_RelationListImpl value,
-          $Res Function(_$OperationValue_RelationListImpl) then) =
-      __$$OperationValue_RelationListImplCopyWithImpl<$Res>;
+abstract class _$$OperationValue_RelationListCopyWith<$Res> {
+  factory _$$OperationValue_RelationListCopyWith(
+          _$OperationValue_RelationList value,
+          $Res Function(_$OperationValue_RelationList) then) =
+      __$$OperationValue_RelationListCopyWithImpl<$Res>;
   @useResult
   $Res call({List<String> field0});
 }
 
 /// @nodoc
-class __$$OperationValue_RelationListImplCopyWithImpl<$Res>
-    extends _$OperationValueCopyWithImpl<$Res,
-        _$OperationValue_RelationListImpl>
-    implements _$$OperationValue_RelationListImplCopyWith<$Res> {
-  __$$OperationValue_RelationListImplCopyWithImpl(
-      _$OperationValue_RelationListImpl _value,
-      $Res Function(_$OperationValue_RelationListImpl) _then)
+class __$$OperationValue_RelationListCopyWithImpl<$Res>
+    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_RelationList>
+    implements _$$OperationValue_RelationListCopyWith<$Res> {
+  __$$OperationValue_RelationListCopyWithImpl(
+      _$OperationValue_RelationList _value,
+      $Res Function(_$OperationValue_RelationList) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1248,7 +1238,7 @@ class __$$OperationValue_RelationListImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$OperationValue_RelationListImpl(
+    return _then(_$OperationValue_RelationList(
       null == field0
           ? _value._field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -1259,8 +1249,8 @@ class __$$OperationValue_RelationListImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$OperationValue_RelationListImpl implements OperationValue_RelationList {
-  const _$OperationValue_RelationListImpl(final List<String> field0)
+class _$OperationValue_RelationList implements OperationValue_RelationList {
+  const _$OperationValue_RelationList(final List<String> field0)
       : _field0 = field0;
 
   final List<String> _field0;
@@ -1280,7 +1270,7 @@ class _$OperationValue_RelationListImpl implements OperationValue_RelationList {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$OperationValue_RelationListImpl &&
+            other is _$OperationValue_RelationList &&
             const DeepCollectionEquality().equals(other._field0, _field0));
   }
 
@@ -1291,9 +1281,9 @@ class _$OperationValue_RelationListImpl implements OperationValue_RelationList {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$OperationValue_RelationListImplCopyWith<_$OperationValue_RelationListImpl>
-      get copyWith => __$$OperationValue_RelationListImplCopyWithImpl<
-          _$OperationValue_RelationListImpl>(this, _$identity);
+  _$$OperationValue_RelationListCopyWith<_$OperationValue_RelationList>
+      get copyWith => __$$OperationValue_RelationListCopyWithImpl<
+          _$OperationValue_RelationList>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1406,33 +1396,32 @@ class _$OperationValue_RelationListImpl implements OperationValue_RelationList {
 
 abstract class OperationValue_RelationList implements OperationValue {
   const factory OperationValue_RelationList(final List<String> field0) =
-      _$OperationValue_RelationListImpl;
+      _$OperationValue_RelationList;
 
   @override
   List<String> get field0;
   @JsonKey(ignore: true)
-  _$$OperationValue_RelationListImplCopyWith<_$OperationValue_RelationListImpl>
+  _$$OperationValue_RelationListCopyWith<_$OperationValue_RelationList>
       get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$OperationValue_PinnedRelationImplCopyWith<$Res> {
-  factory _$$OperationValue_PinnedRelationImplCopyWith(
-          _$OperationValue_PinnedRelationImpl value,
-          $Res Function(_$OperationValue_PinnedRelationImpl) then) =
-      __$$OperationValue_PinnedRelationImplCopyWithImpl<$Res>;
+abstract class _$$OperationValue_PinnedRelationCopyWith<$Res> {
+  factory _$$OperationValue_PinnedRelationCopyWith(
+          _$OperationValue_PinnedRelation value,
+          $Res Function(_$OperationValue_PinnedRelation) then) =
+      __$$OperationValue_PinnedRelationCopyWithImpl<$Res>;
   @useResult
   $Res call({String field0});
 }
 
 /// @nodoc
-class __$$OperationValue_PinnedRelationImplCopyWithImpl<$Res>
-    extends _$OperationValueCopyWithImpl<$Res,
-        _$OperationValue_PinnedRelationImpl>
-    implements _$$OperationValue_PinnedRelationImplCopyWith<$Res> {
-  __$$OperationValue_PinnedRelationImplCopyWithImpl(
-      _$OperationValue_PinnedRelationImpl _value,
-      $Res Function(_$OperationValue_PinnedRelationImpl) _then)
+class __$$OperationValue_PinnedRelationCopyWithImpl<$Res>
+    extends _$OperationValueCopyWithImpl<$Res, _$OperationValue_PinnedRelation>
+    implements _$$OperationValue_PinnedRelationCopyWith<$Res> {
+  __$$OperationValue_PinnedRelationCopyWithImpl(
+      _$OperationValue_PinnedRelation _value,
+      $Res Function(_$OperationValue_PinnedRelation) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1440,7 +1429,7 @@ class __$$OperationValue_PinnedRelationImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$OperationValue_PinnedRelationImpl(
+    return _then(_$OperationValue_PinnedRelation(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -1451,9 +1440,8 @@ class __$$OperationValue_PinnedRelationImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$OperationValue_PinnedRelationImpl
-    implements OperationValue_PinnedRelation {
-  const _$OperationValue_PinnedRelationImpl(this.field0);
+class _$OperationValue_PinnedRelation implements OperationValue_PinnedRelation {
+  const _$OperationValue_PinnedRelation(this.field0);
 
   @override
   final String field0;
@@ -1467,7 +1455,7 @@ class _$OperationValue_PinnedRelationImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$OperationValue_PinnedRelationImpl &&
+            other is _$OperationValue_PinnedRelation &&
             (identical(other.field0, field0) || other.field0 == field0));
   }
 
@@ -1477,10 +1465,9 @@ class _$OperationValue_PinnedRelationImpl
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$OperationValue_PinnedRelationImplCopyWith<
-          _$OperationValue_PinnedRelationImpl>
-      get copyWith => __$$OperationValue_PinnedRelationImplCopyWithImpl<
-          _$OperationValue_PinnedRelationImpl>(this, _$identity);
+  _$$OperationValue_PinnedRelationCopyWith<_$OperationValue_PinnedRelation>
+      get copyWith => __$$OperationValue_PinnedRelationCopyWithImpl<
+          _$OperationValue_PinnedRelation>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1593,34 +1580,33 @@ class _$OperationValue_PinnedRelationImpl
 
 abstract class OperationValue_PinnedRelation implements OperationValue {
   const factory OperationValue_PinnedRelation(final String field0) =
-      _$OperationValue_PinnedRelationImpl;
+      _$OperationValue_PinnedRelation;
 
   @override
   String get field0;
   @JsonKey(ignore: true)
-  _$$OperationValue_PinnedRelationImplCopyWith<
-          _$OperationValue_PinnedRelationImpl>
+  _$$OperationValue_PinnedRelationCopyWith<_$OperationValue_PinnedRelation>
       get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$OperationValue_PinnedRelationListImplCopyWith<$Res> {
-  factory _$$OperationValue_PinnedRelationListImplCopyWith(
-          _$OperationValue_PinnedRelationListImpl value,
-          $Res Function(_$OperationValue_PinnedRelationListImpl) then) =
-      __$$OperationValue_PinnedRelationListImplCopyWithImpl<$Res>;
+abstract class _$$OperationValue_PinnedRelationListCopyWith<$Res> {
+  factory _$$OperationValue_PinnedRelationListCopyWith(
+          _$OperationValue_PinnedRelationList value,
+          $Res Function(_$OperationValue_PinnedRelationList) then) =
+      __$$OperationValue_PinnedRelationListCopyWithImpl<$Res>;
   @useResult
   $Res call({List<String> field0});
 }
 
 /// @nodoc
-class __$$OperationValue_PinnedRelationListImplCopyWithImpl<$Res>
+class __$$OperationValue_PinnedRelationListCopyWithImpl<$Res>
     extends _$OperationValueCopyWithImpl<$Res,
-        _$OperationValue_PinnedRelationListImpl>
-    implements _$$OperationValue_PinnedRelationListImplCopyWith<$Res> {
-  __$$OperationValue_PinnedRelationListImplCopyWithImpl(
-      _$OperationValue_PinnedRelationListImpl _value,
-      $Res Function(_$OperationValue_PinnedRelationListImpl) _then)
+        _$OperationValue_PinnedRelationList>
+    implements _$$OperationValue_PinnedRelationListCopyWith<$Res> {
+  __$$OperationValue_PinnedRelationListCopyWithImpl(
+      _$OperationValue_PinnedRelationList _value,
+      $Res Function(_$OperationValue_PinnedRelationList) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1628,7 +1614,7 @@ class __$$OperationValue_PinnedRelationListImplCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$OperationValue_PinnedRelationListImpl(
+    return _then(_$OperationValue_PinnedRelationList(
       null == field0
           ? _value._field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -1639,9 +1625,9 @@ class __$$OperationValue_PinnedRelationListImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$OperationValue_PinnedRelationListImpl
+class _$OperationValue_PinnedRelationList
     implements OperationValue_PinnedRelationList {
-  const _$OperationValue_PinnedRelationListImpl(final List<String> field0)
+  const _$OperationValue_PinnedRelationList(final List<String> field0)
       : _field0 = field0;
 
   final List<String> _field0;
@@ -1661,7 +1647,7 @@ class _$OperationValue_PinnedRelationListImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$OperationValue_PinnedRelationListImpl &&
+            other is _$OperationValue_PinnedRelationList &&
             const DeepCollectionEquality().equals(other._field0, _field0));
   }
 
@@ -1672,10 +1658,10 @@ class _$OperationValue_PinnedRelationListImpl
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$OperationValue_PinnedRelationListImplCopyWith<
-          _$OperationValue_PinnedRelationListImpl>
-      get copyWith => __$$OperationValue_PinnedRelationListImplCopyWithImpl<
-          _$OperationValue_PinnedRelationListImpl>(this, _$identity);
+  _$$OperationValue_PinnedRelationListCopyWith<
+          _$OperationValue_PinnedRelationList>
+      get copyWith => __$$OperationValue_PinnedRelationListCopyWithImpl<
+          _$OperationValue_PinnedRelationList>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1788,12 +1774,12 @@ class _$OperationValue_PinnedRelationListImpl
 
 abstract class OperationValue_PinnedRelationList implements OperationValue {
   const factory OperationValue_PinnedRelationList(final List<String> field0) =
-      _$OperationValue_PinnedRelationListImpl;
+      _$OperationValue_PinnedRelationList;
 
   @override
   List<String> get field0;
   @JsonKey(ignore: true)
-  _$$OperationValue_PinnedRelationListImplCopyWith<
-          _$OperationValue_PinnedRelationListImpl>
+  _$$OperationValue_PinnedRelationListCopyWith<
+          _$OperationValue_PinnedRelationList>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/p2panda/native/build.rs
+++ b/packages/p2panda/native/build.rs
@@ -1,0 +1,21 @@
+use std::env;
+
+// The new NDK doesn't link to `libgcc` anymore, which breaks our our libraries since they depended
+// on the symbols from libclang_rt.builtins-x86_64-android` like `__extenddftf2`. See
+// https://github.com/bbqsrc/cargo-ndk/issues/94 for details.
+//
+// The change works around this by manually linking to the libclang_rt.builtins-x86_64-android
+// library in this case.
+fn main() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    if target_arch == "x86_64" && target_os == "android" {
+        let android_home = env::var("ANDROID_HOME").expect("ANDROID_HOME not set");
+        const ANDROID_NDK_VERSION: &str = "25.2.9519653";
+        const LINUX_X86_64_LIB_DIR: &str =
+            "/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/14.0.7/lib/linux/";
+        println!("cargo:rustc-link-search={android_home}/ndk/{ANDROID_NDK_VERSION}/{LINUX_X86_64_LIB_DIR}");
+        println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
+    }
+}

--- a/packages/p2panda/native/build.rs
+++ b/packages/p2panda/native/build.rs
@@ -1,20 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::env;
 
-// The new NDK doesn't link to `libgcc` anymore, which breaks our our libraries since they depended
-// on the symbols from libclang_rt.builtins-x86_64-android` like `__extenddftf2`. See
-// https://github.com/bbqsrc/cargo-ndk/issues/94 for details.
-//
-// The change works around this by manually linking to the libclang_rt.builtins-x86_64-android
-// library in this case.
+/// Pinned NDK version, needs to be installed on machine.
+const ANDROID_NDK_VERSION: &'static str = "25.2.9519653";
+
+/// x86-64 linux standard library path inside NDK directory.
+const LINUX_X86_64_LIB_DIR: &'static str =
+    "/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/14.0.7/lib/linux/";
+
 fn main() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
+    // The new NDK doesn't link to `libgcc` anymore, which breaks our our libraries since they
+    // depended on the symbols from `libclang_rt.builtins-x86_64-android` like `__extenddftf2`. See
+    // https://github.com/bbqsrc/cargo-ndk/issues/94 for details.
+    //
+    // The change works around this by manually linking to the
+    // `libclang_rt.builtins-x86_64-android` library in this case.
     if target_arch == "x86_64" && target_os == "android" {
         let android_home = env::var("ANDROID_HOME").expect("ANDROID_HOME not set");
-        const ANDROID_NDK_VERSION: &str = "25.2.9519653";
-        const LINUX_X86_64_LIB_DIR: &str =
-            "/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/14.0.7/lib/linux/";
         println!("cargo:rustc-link-search={android_home}/ndk/{ANDROID_NDK_VERSION}/{LINUX_X86_64_LIB_DIR}");
         println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
     }


### PR DESCRIPTION
The new NDK doesn't link to `libgcc` anymore, which breaks our libraries since they depended on the symbols from `libclang_rt.builtins-x86_64-android` like `__extenddftf2`. See https://github.com/bbqsrc/cargo-ndk/issues/94 for details.

The change works around this by manually linking to the `libclang_rt.builtins-x86_64-android` library in this case.

This change pins the required NDK version to `25.2.9519653` and fixes an issue running the application for x86-64 targets. I'll update our README.md to address that requirement.