### PR TITLE
Show related sightings in species profile screen

### DIFF
--- a/packages/app/lib/ui/screens/all_sightings.dart
+++ b/packages/app/lib/ui/screens/all_sightings.dart
@@ -65,11 +65,11 @@ class ScrollView extends StatelessWidget {
             const SizedBox(height: 30.0),
             Container(
                 padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 20.0),
-                decoration: new MagnoliaWavesBackground(),
+                decoration: const MagnoliaWavesBackground(),
                 child: Container(
                     width: double.infinity,
                     padding: const EdgeInsets.only(top: 30.0, bottom: 20.0),
-                    child: SightingsList(paginator: this.paginator))),
+                    child: SightingsList(paginator: paginator))),
             const SizedBox(height: 40.0),
           ])),
     );

--- a/packages/app/lib/ui/screens/all_sightings.dart
+++ b/packages/app/lib/ui/screens/all_sightings.dart
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'package:app/ui/widgets/pagination_cards_list.dart';
 import 'package:flutter/material.dart';
 
 import 'package:app/models/base.dart';
@@ -9,7 +8,7 @@ import 'package:app/router.dart';
 import 'package:app/ui/colors.dart';
 import 'package:app/ui/widgets/fab.dart';
 import 'package:app/ui/widgets/scaffold.dart';
-import 'package:app/ui/widgets/sighting_card.dart';
+import 'package:app/ui/widgets/sightings_list.dart';
 
 class AllSightingsScreen extends StatelessWidget {
   const AllSightingsScreen({super.key});
@@ -64,48 +63,15 @@ class ScrollView extends StatelessWidget {
             const TopBar(),
             const BouncyBee(),
             const SizedBox(height: 30.0),
-            SightingsList(paginator: paginator),
+            Container(
+                padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 20.0),
+                decoration: new MagnoliaWavesBackground(),
+                child: Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.only(top: 30.0, bottom: 20.0),
+                    child: SightingsList(paginator: this.paginator))),
             const SizedBox(height: 40.0),
           ])),
-    );
-  }
-}
-
-class SightingsList extends StatefulWidget {
-  final Paginator<Sighting> paginator;
-
-  const SightingsList({super.key, required this.paginator});
-
-  @override
-  State<SightingsList> createState() => _SightingsListState();
-}
-
-class _SightingsListState extends State<SightingsList> {
-  Widget _item(Sighting sighting) {
-    return SightingCard(
-        onTap: () => router.pushNamed(RoutePaths.sighting.name,
-            pathParameters: {'documentId': sighting.id}),
-        date: sighting.datetime,
-        localName: sighting.localName,
-        species: sighting.species,
-        image: sighting.images.firstOrNull);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 20.0),
-      decoration: const MagnoliaWavesBackground(),
-      child: Container(
-          width: double.infinity,
-          padding: const EdgeInsets.only(top: 30.0, bottom: 20.0),
-          child: PaginationList<Sighting>(
-              builder: (Sighting sighting) {
-                return Container(
-                    padding: const EdgeInsets.only(bottom: 20.0),
-                    child: _item(sighting));
-              },
-              paginator: widget.paginator)),
     );
   }
 }

--- a/packages/app/lib/ui/screens/all_species.dart
+++ b/packages/app/lib/ui/screens/all_species.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'package:app/ui/widgets/pagination_cards_list.dart';
+import 'package:app/ui/widgets/pagination_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 

--- a/packages/app/lib/ui/screens/species.dart
+++ b/packages/app/lib/ui/screens/species.dart
@@ -94,7 +94,7 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.only(top: 10.0, right: 20.0, left: 20.0),
+      padding: const EdgeInsets.only(top: 0.0, right: 20.0, left: 20.0),
       decoration: const SeaWavesBackground(),
       child: CustomScrollView(
         slivers: [

--- a/packages/app/lib/ui/screens/species.dart
+++ b/packages/app/lib/ui/screens/species.dart
@@ -4,11 +4,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
+import 'package:app/io/p2panda/publish.dart';
+import 'package:app/models/base.dart';
+import 'package:app/models/sightings.dart';
 import 'package:app/models/species.dart';
 import 'package:app/models/taxonomy_species.dart';
 import 'package:app/ui/colors.dart';
 import 'package:app/ui/widgets/error_card.dart';
 import 'package:app/ui/widgets/scaffold.dart';
+import 'package:app/ui/widgets/sightings_tiles.dart';
 import 'package:app/ui/widgets/species_field.dart';
 import 'package:app/ui/widgets/text_field.dart';
 
@@ -107,8 +111,23 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
         EditableTextField(species.description,
             title: AppLocalizations.of(context)!.speciesDescription,
             onUpdate: _updateDescription),
+        RelatedSightings(id: species.id),
       ]),
     );
+  }
+}
+
+class RelatedSightings extends StatelessWidget {
+  final DocumentId id;
+
+  const RelatedSightings({super.key, required this.id});
+
+  @override
+  Widget build(BuildContext context) {
+    final Paginator<Sighting> paginator =
+        SpeciesSightingsPaginator(id);
+
+    return SightingsTiles(paginator: paginator);
   }
 }
 

--- a/packages/app/lib/ui/screens/species.dart
+++ b/packages/app/lib/ui/screens/species.dart
@@ -31,32 +31,29 @@ class _SpeciesScreenState extends State<SpeciesScreen> {
     return MeliScaffold(
         title: AppLocalizations.of(context)!.speciesScreenTitle,
         appBarColor: MeliColors.peach,
-        body: SingleChildScrollView(
-          child: Query(
-              options: QueryOptions(
-                  document: gql(speciesQuery(widget.documentId))),
-              builder: (result,
-                  {VoidCallback? refetch, FetchMore? fetchMore}) {
-                if (result.hasException) {
-                  return ErrorCard(message: result.exception.toString());
-                }
+        body: Query(
+            options:
+                QueryOptions(document: gql(speciesQuery(widget.documentId))),
+            builder: (result, {VoidCallback? refetch, FetchMore? fetchMore}) {
+              if (result.hasException) {
+                return ErrorCard(message: result.exception.toString());
+              }
 
-                if (result.isLoading) {
-                  return const Center(
-                    child: SizedBox(
-                        width: 50,
-                        height: 50,
-                        child: CircularProgressIndicator(
-                            color: MeliColors.black)),
-                  );
-                }
+              if (result.isLoading) {
+                return const Center(
+                  child: SizedBox(
+                      width: 50,
+                      height: 50,
+                      child:
+                          CircularProgressIndicator(color: MeliColors.black)),
+                );
+              }
 
-                final species = Species.fromJson(
-                    result.data?['species'] as Map<String, dynamic>);
+              final species = Species.fromJson(
+                  result.data?['species'] as Map<String, dynamic>);
 
-                return SpeciesProfile(species);
-              }),
-        ));
+              return SpeciesProfile(species);
+            }));
   }
 }
 
@@ -97,22 +94,29 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.only(
-          top: 10.0, right: 20.0, bottom: 20.0, left: 20.0),
+      padding: const EdgeInsets.only(top: 10.0, right: 20.0, left: 20.0),
       decoration: const SeaWavesBackground(),
-      child: Wrap(runSpacing: 20.0, children: [
-        SpeciesProfileTitle(species.species.name),
-        const SizedBox(height: 100.0),
-        SpeciesField(
-          species.species,
-          allowNull: false,
-          onUpdate: _updateTaxon,
-        ),
-        EditableTextField(species.description,
-            title: AppLocalizations.of(context)!.speciesDescription,
-            onUpdate: _updateDescription),
-        RelatedSightings(id: species.id),
-      ]),
+      child: CustomScrollView(
+        slivers: [
+          SliverList(
+              delegate: SliverChildListDelegate([
+            SpeciesProfileTitle(species.species.name),
+            const SizedBox(height: 100.0),
+            SpeciesField(
+              species.species,
+              allowNull: false,
+              onUpdate: _updateTaxon,
+            ),
+            const SizedBox(height: 20.0),
+            EditableTextField(species.description,
+                title: AppLocalizations.of(context)!.speciesDescription,
+                onUpdate: _updateDescription),
+            const SizedBox(height: 20.0),
+          ])),
+          RelatedSightings(id: species.id),
+          const SliverToBoxAdapter(child: SizedBox(height: 20.0)),
+        ],
+      ),
     );
   }
 }
@@ -124,9 +128,7 @@ class RelatedSightings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Paginator<Sighting> paginator =
-        SpeciesSightingsPaginator(id);
-
+    final Paginator<Sighting> paginator = SpeciesSightingsPaginator(id);
     return SightingsTiles(paginator: paginator);
   }
 }

--- a/packages/app/lib/ui/widgets/pagination_cards_list.dart
+++ b/packages/app/lib/ui/widgets/pagination_cards_list.dart
@@ -16,11 +16,15 @@ typedef PaginationBuilder<T> = Widget Function(
   T document,
 );
 
-class PaginationList<T> extends StatelessWidget {
-  final PaginationBuilder<T> builder;
+typedef ContainerBuilder<T> = Widget Function(
+  List<T> collection,
+);
+
+class PaginationBase<T> extends StatelessWidget {
+  final ContainerBuilder<T> builder;
   final Paginator<T> paginator;
 
-  const PaginationList(
+  const PaginationBase(
       {super.key, required this.builder, required this.paginator});
 
   Widget _error(BuildContext context, String errorMessage) {
@@ -91,14 +95,38 @@ class PaginationList<T> extends StatelessWidget {
         }
 
         return Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              ...data.documents.map((document) => this.builder(document)),
-              if (data.hasNextPage)
-                this._loadMore(context, result.isLoading, onLoadMore: () {
-                  fetchMore!(opts);
-                })
-            ]);
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            this.builder(data.documents),
+            if (data.hasNextPage)
+              this._loadMore(context, result.isLoading, onLoadMore: () {
+                fetchMore!(opts);
+              })
+          ],
+        );
+      },
+    );
+  }
+}
+
+class PaginationList<T> extends StatelessWidget {
+  final PaginationBuilder<T> builder;
+  final Paginator<T> paginator;
+
+  const PaginationList(
+      {super.key, required this.builder, required this.paginator});
+
+  @override
+  Widget build(BuildContext context) {
+    return PaginationBase<T>(
+      paginator: this.paginator,
+      builder: (List<T> collection) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            ...collection.map((document) => this.builder(document)),
+          ],
+        );
       },
     );
   }

--- a/packages/app/lib/ui/widgets/pagination_list.dart
+++ b/packages/app/lib/ui/widgets/pagination_list.dart
@@ -142,16 +142,17 @@ class SliverPaginationBase<T> extends StatelessWidget {
 
   Widget _loadMore(BuildContext context, bool isLoading,
       {required VoidCallback onLoadMore}) {
-    return SliverToBoxAdapter(
-        child: Column(children: [
+    return MultiSliver(children: [
+      const SizedBox(height: 20.0),
       isLoading
           ? this._loading()
-          : ElevatedButton(
+          : Center(
+              child: ElevatedButton(
               onPressed: onLoadMore,
               child: Text(AppLocalizations.of(context)!.paginationListLoadMore,
                   style: const TextStyle(color: MeliColors.black)),
-            )
-    ]));
+            ))
+    ]);
   }
 
   @override
@@ -188,7 +189,7 @@ class SliverPaginationBase<T> extends StatelessWidget {
           return this._emptyResult(context);
         }
 
-        return SliverStack(children: [
+        return MultiSliver(children: [
           this.builder(data.documents),
           if (data.hasNextPage)
             this._loadMore(context, result.isLoading, onLoadMore: () {

--- a/packages/app/lib/ui/widgets/pagination_list.dart
+++ b/packages/app/lib/ui/widgets/pagination_list.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:gql/ast.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:sliver_tools/sliver_tools.dart';
 
 import 'package:app/models/base.dart';
 import 'package:app/ui/colors.dart';
@@ -109,6 +110,96 @@ class PaginationBase<T> extends StatelessWidget {
   }
 }
 
+class SliverPaginationBase<T> extends StatelessWidget {
+  final ContainerBuilder<T> builder;
+  final Paginator<T> paginator;
+
+  const SliverPaginationBase(
+      {super.key, required this.builder, required this.paginator});
+
+  Widget _error(BuildContext context, String errorMessage) {
+    return SliverToBoxAdapter(
+        child: ErrorCard(
+            message: AppLocalizations.of(context)!
+                .paginationListError(errorMessage)));
+  }
+
+  Widget _loading() {
+    return SliverToBoxAdapter(
+        child: Center(
+            child: Container(
+                padding: const EdgeInsets.all(30.0),
+                child: const CircularProgressIndicator(
+                  color: MeliColors.black,
+                ))));
+  }
+
+  Widget _emptyResult(BuildContext context) {
+    return SliverToBoxAdapter(
+        child: InfoCard(
+            message: AppLocalizations.of(context)!.paginationListNoResults));
+  }
+
+  Widget _loadMore(BuildContext context, bool isLoading,
+      {required VoidCallback onLoadMore}) {
+    return SliverToBoxAdapter(
+        child: Column(children: [
+      isLoading
+          ? this._loading()
+          : ElevatedButton(
+              onPressed: onLoadMore,
+              child: Text(AppLocalizations.of(context)!.paginationListLoadMore,
+                  style: const TextStyle(color: MeliColors.black)),
+            )
+    ]));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Query(
+      options: QueryOptions(document: this.paginator.nextPageQuery(null)),
+      builder: (result, {VoidCallback? refetch, FetchMore? fetchMore}) {
+        if (this.paginator.refresh == null) {
+          // Workaround to access `refetch` method from the outside
+          this.paginator.refresh = refetch;
+        }
+
+        if (result.hasException) {
+          return this._error(context, result.exception.toString());
+        }
+
+        if (result.isLoading && result.data == null) {
+          return this._loading();
+        }
+
+        final data =
+            this.paginator.parseJSON(result.data as Map<String, dynamic>);
+
+        FetchMoreOptions opts = FetchMoreOptions(
+          document: this.paginator.nextPageQuery(data.endCursor),
+          updateQuery: (previousResultData, fetchMoreResultData) {
+            return this
+                .paginator
+                .mergeResponses(previousResultData!, fetchMoreResultData!);
+          },
+        );
+
+        if (data.documents.isEmpty) {
+          return this._emptyResult(context);
+        }
+
+        return SliverStack(children: [
+          this.builder(data.documents),
+          if (data.hasNextPage)
+            this._loadMore(context, result.isLoading, onLoadMore: () {
+              fetchMore!(opts);
+            })
+        ]);
+      },
+    );
+  }
+}
+
 class PaginationList<T> extends StatelessWidget {
   final PaginationBuilder<T> builder;
   final Paginator<T> paginator;
@@ -126,6 +217,32 @@ class PaginationList<T> extends StatelessWidget {
           children: <Widget>[
             ...collection.map((document) => this.builder(document)),
           ],
+        );
+      },
+    );
+  }
+}
+
+class PaginationGrid<T> extends StatelessWidget {
+  final PaginationBuilder<T> builder;
+  final Paginator<T> paginator;
+
+  const PaginationGrid(
+      {super.key, required this.builder, required this.paginator});
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverPaginationBase<T>(
+      paginator: this.paginator,
+      builder: (List<T> collection) {
+        return SliverGrid.builder(
+          itemCount: collection.length,
+          itemBuilder: (BuildContext context, int index) {
+            return this.builder(collection[index]);
+          },
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 2,
+          ),
         );
       },
     );

--- a/packages/app/lib/ui/widgets/sightings_list.dart
+++ b/packages/app/lib/ui/widgets/sightings_list.dart
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:flutter/material.dart';
+
+import 'package:app/models/base.dart';
+import 'package:app/models/sightings.dart';
+import 'package:app/router.dart';
+import 'package:app/ui/widgets/pagination_cards_list.dart';
+import 'package:app/ui/widgets/sighting_card.dart';
+
+class SightingsList extends StatefulWidget {
+  final Paginator<Sighting> paginator;
+
+  SightingsList({super.key, required this.paginator});
+
+  @override
+  State<SightingsList> createState() => _SightingsListState();
+}
+
+class _SightingsListState extends State<SightingsList> {
+  Widget _item(Sighting sighting) {
+    return SightingCard(
+        onTap: () => router.pushNamed(RoutePaths.sighting.name,
+            pathParameters: {'documentId': sighting.id}),
+        date: sighting.datetime,
+        localName: sighting.localName,
+        species: sighting.species,
+        image: sighting.images.firstOrNull);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PaginationList<Sighting>(
+        builder: (Sighting sighting) {
+          return Container(
+              padding: EdgeInsets.only(bottom: 20.0),
+              child: this._item(sighting));
+        },
+        paginator: widget.paginator);
+  }
+}

--- a/packages/app/lib/ui/widgets/sightings_list.dart
+++ b/packages/app/lib/ui/widgets/sightings_list.dart
@@ -11,7 +11,7 @@ import 'package:app/ui/widgets/sighting_card.dart';
 class SightingsList extends StatefulWidget {
   final Paginator<Sighting> paginator;
 
-  SightingsList({super.key, required this.paginator});
+  const SightingsList({super.key, required this.paginator});
 
   @override
   State<SightingsList> createState() => _SightingsListState();
@@ -33,8 +33,8 @@ class _SightingsListState extends State<SightingsList> {
     return PaginationList<Sighting>(
         builder: (Sighting sighting) {
           return Container(
-              padding: EdgeInsets.only(bottom: 20.0),
-              child: this._item(sighting));
+              padding: const EdgeInsets.only(bottom: 20.0),
+              child: _item(sighting));
         },
         paginator: widget.paginator);
   }

--- a/packages/app/lib/ui/widgets/sightings_list.dart
+++ b/packages/app/lib/ui/widgets/sightings_list.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:app/models/base.dart';
 import 'package:app/models/sightings.dart';
 import 'package:app/router.dart';
-import 'package:app/ui/widgets/pagination_cards_list.dart';
+import 'package:app/ui/widgets/pagination_list.dart';
 import 'package:app/ui/widgets/sighting_card.dart';
 
 class SightingsList extends StatefulWidget {

--- a/packages/app/lib/ui/widgets/sightings_tiles.dart
+++ b/packages/app/lib/ui/widgets/sightings_tiles.dart
@@ -12,7 +12,7 @@ import 'package:app/ui/widgets/pagination_cards_list.dart';
 class SightingsTiles extends StatefulWidget {
   final Paginator<Sighting> paginator;
 
-  SightingsTiles({super.key, required this.paginator});
+  const SightingsTiles({super.key, required this.paginator});
 
   @override
   State<SightingsTiles> createState() => _SightingsTilesState();
@@ -32,8 +32,8 @@ class _SightingsTilesState extends State<SightingsTiles> {
     return PaginationList<Sighting>(
         builder: (Sighting sighting) {
           return Container(
-              padding: EdgeInsets.only(bottom: 20.0),
-              child: this._item(sighting));
+              padding: const EdgeInsets.only(bottom: 20.0),
+              child: _item(sighting));
         },
         paginator: widget.paginator);
   }
@@ -51,7 +51,7 @@ class SightingTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
       return Container(
-          constraints: BoxConstraints(maxWidth: 50.0),
+          constraints: const BoxConstraints(maxWidth: 50.0),
           child: MeliImage(image: image));
     });
   }

--- a/packages/app/lib/ui/widgets/sightings_tiles.dart
+++ b/packages/app/lib/ui/widgets/sightings_tiles.dart
@@ -7,7 +7,7 @@ import 'package:app/models/blobs.dart';
 import 'package:app/models/sightings.dart';
 import 'package:app/router.dart';
 import 'package:app/ui/widgets/image.dart';
-import 'package:app/ui/widgets/pagination_cards_list.dart';
+import 'package:app/ui/widgets/pagination_list.dart';
 
 class SightingsTiles extends StatefulWidget {
   final Paginator<Sighting> paginator;
@@ -29,11 +29,9 @@ class _SightingsTilesState extends State<SightingsTiles> {
 
   @override
   Widget build(BuildContext context) {
-    return PaginationList<Sighting>(
+    return PaginationGrid<Sighting>(
         builder: (Sighting sighting) {
-          return Container(
-              padding: const EdgeInsets.only(bottom: 20.0),
-              child: _item(sighting));
+          return _item(sighting);
         },
         paginator: widget.paginator);
   }

--- a/packages/app/lib/ui/widgets/sightings_tiles.dart
+++ b/packages/app/lib/ui/widgets/sightings_tiles.dart
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:flutter/material.dart';
+
+import 'package:app/models/base.dart';
+import 'package:app/models/blobs.dart';
+import 'package:app/models/sightings.dart';
+import 'package:app/router.dart';
+import 'package:app/ui/widgets/image.dart';
+import 'package:app/ui/widgets/pagination_cards_list.dart';
+
+class SightingsTiles extends StatefulWidget {
+  final Paginator<Sighting> paginator;
+
+  SightingsTiles({super.key, required this.paginator});
+
+  @override
+  State<SightingsTiles> createState() => _SightingsTilesState();
+}
+
+class _SightingsTilesState extends State<SightingsTiles> {
+  Widget _item(Sighting sighting) {
+    return SightingTile(
+        onTap: () => router.pushNamed(RoutePaths.sighting.name,
+            pathParameters: {'documentId': sighting.id}),
+        date: sighting.datetime,
+        image: sighting.images.firstOrNull);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PaginationList<Sighting>(
+        builder: (Sighting sighting) {
+          return Container(
+              padding: EdgeInsets.only(bottom: 20.0),
+              child: this._item(sighting));
+        },
+        paginator: widget.paginator);
+  }
+}
+
+class SightingTile extends StatelessWidget {
+  final Blob? image;
+  final DateTime date;
+  final VoidCallback onTap;
+
+  const SightingTile(
+      {super.key, this.image, required this.date, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraints) {
+      return Container(
+          constraints: BoxConstraints(maxWidth: 50.0),
+          child: MeliImage(image: image));
+    });
+  }
+}

--- a/packages/app/lib/ui/widgets/sightings_tiles.dart
+++ b/packages/app/lib/ui/widgets/sightings_tiles.dart
@@ -6,6 +6,8 @@ import 'package:app/models/base.dart';
 import 'package:app/models/blobs.dart';
 import 'package:app/models/sightings.dart';
 import 'package:app/router.dart';
+import 'package:app/ui/colors.dart';
+import 'package:app/ui/widgets/card.dart';
 import 'package:app/ui/widgets/image.dart';
 import 'package:app/ui/widgets/pagination_list.dart';
 
@@ -37,7 +39,7 @@ class _SightingsTilesState extends State<SightingsTiles> {
   }
 }
 
-class SightingTile extends StatelessWidget {
+class SightingTile extends StatefulWidget {
   final Blob? image;
   final DateTime date;
   final VoidCallback onTap;
@@ -46,11 +48,35 @@ class SightingTile extends StatelessWidget {
       {super.key, this.image, required this.date, required this.onTap});
 
   @override
+  State<SightingTile> createState() => _SightingTileState();
+}
+
+class _SightingTileState extends State<SightingTile> {
+  bool isSelected = false;
+
+  @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(builder: (context, constraints) {
-      return Container(
-          constraints: const BoxConstraints(maxWidth: 50.0),
-          child: MeliImage(image: image));
-    });
+    return GestureDetector(
+      onTap: widget.onTap,
+      onTapDown: (details) {
+        setState(() {
+          isSelected = true;
+        });
+      },
+      onTapUp: (details) {
+        setState(() {
+          isSelected = false;
+        });
+      },
+      onTapCancel: () {
+        setState(() {
+          isSelected = false;
+        });
+      },
+      child: MeliCard(
+          borderColor: isSelected ? MeliColors.black : MeliColors.white,
+          borderWidth: 3.0,
+          child: MeliImage(image: widget.image)),
+    );
   }
 }

--- a/packages/app/lib/ui/widgets/sightings_tiles.dart
+++ b/packages/app/lib/ui/widgets/sightings_tiles.dart
@@ -76,7 +76,12 @@ class _SightingTileState extends State<SightingTile> {
       child: MeliCard(
           borderColor: isSelected ? MeliColors.black : MeliColors.white,
           borderWidth: 3.0,
-          child: MeliImage(image: widget.image)),
+          child: Container(
+              clipBehavior: Clip.hardEdge,
+              decoration: const ShapeDecoration(
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(10.0)))),
+              child: MeliImage(image: widget.image))),
     );
   }
 }

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -888,6 +888,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  sliver_tools:
+    dependency: "direct main"
+    description:
+      name: sliver_tools
+      sha256: eae28220badfb9d0559207badcbbc9ad5331aac829a88cb0964d330d2a4636a6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.12"
   source_span:
     dependency: transitive
     description:

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   path: 1.9.0
   path_provider: 2.1.3
   shared_preferences: 2.2.2
+  sliver_tools: 0.2.12
   toml: 0.15.0
 
 dev_dependencies:


### PR DESCRIPTION
This PR introduces a nice, paginated grid list in the "Species" profile screen with related sightings.

Since grid views are so called ["slivers"](https://api.flutter.dev/flutter/widgets/CustomScrollView/slivers.html) in Flutter I've needed to do a bit of refactoring to make it work, as they apparently function very different to widgets and are hardly compatible, on top they require a `CustomScrollView`. After a very steep learning curve I'm happy with the solution now, which on top should give us nice lazy rendering (otherwise all items are always rendered even when not displayed).