### PR TITLE
docs: update documented working rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ providing all p2panda functionality via FFI bindings.
 > environments, other versions might work well too, the exact NDK version is
 > _required_ though.
 
-* [Rust](https://www.rust-lang.org/tools/install) `1.73.0`
+* [Rust](https://www.rust-lang.org/tools/install) `1.74.0`
 * [Android SDK](https://developer.android.com/tools) `34.0.0`
 * [Android NDK](https://developer.android.com/ndk/) `25.2.9519653`
 * [Flutter SDK](https://docs.flutter.dev/get-started/install) `3.13.7` and Dart SDK `3.1.3`


### PR DESCRIPTION
Towards #53

I'm using 1.74.1 locally right now but I'm sure 1.74.0 works fine as the minimum. Wondering what the Rust way of enforcing the minimum Rust version is, if possible.