### PR TITLE
Build apks automatically

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin' # AdoptOpenJDK is now Eclipse Temurin
-        java-version: '12.x'
+        java-version: '11'
     - uses: subosito/flutter-action@v1
       with:
         flutter-version: '2.x'

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  build:
+  build-apk:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -19,7 +19,7 @@ jobs:
         java-version: '11'
     - uses: subosito/flutter-action@v1
       with:
-        flutter-version: '2.x'
+        flutter-version: '3.13.7'
     - run: flutter pub get
     - run: flutter build apk
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -22,7 +22,7 @@ jobs:
         flutter-version: '3.13.7'
     - uses: bluefireteam/melos-action@v2
     - run: flutter pub get
-    - run: flutter build apk --target packages/p2panda_flutter/p2panda_flutter.dart
+    - run: flutter build apk --target packages/p2panda_flutter/lib/p2panda_flutter.dart
     - uses: actions/upload-artifact@v4
       with:
         name: app-release.apk

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -22,8 +22,8 @@ jobs:
         flutter-version: '3.13.7'
     - uses: bluefireteam/melos-action@v2
     - run: flutter pub get
-    - run: flutter build apk
+    - run: flutter build apk --target packages/p2panda_flutter/p2panda_flutter.dart
     - uses: actions/upload-artifact@v4
       with:
         name: app-release.apk
-        path: build/app/outputs/flutter-apk/app-release.apk
+        path: packages/p2panda_flutter/build/app/outputs/flutter-apk/app-release.apk

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,28 @@
+name: Build Android APK
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin' # AdoptOpenJDK is now Eclipse Temurin
+        java-version: '12.x'
+    - uses: subosito/flutter-action@v1
+      with:
+        flutter-version: '2.x'
+    - run: flutter pub get
+    - run: flutter build apk
+    - uses: actions/upload-artifact@v4
+      with:
+        name: app-release.apk
+        path: build/app/outputs/flutter-apk/app-release.apk

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -17,9 +17,10 @@ jobs:
       with:
         distribution: 'temurin' # AdoptOpenJDK is now Eclipse Temurin
         java-version: '11'
-    - uses: subosito/flutter-action@v1
+    - uses: subosito/flutter-action@v2
       with:
         flutter-version: '3.13.7'
+    - uses: bluefireteam/melos-action@v2
     - run: flutter pub get
     - run: flutter build apk
     - uses: actions/upload-artifact@v4

--- a/packages/p2panda_flutter/android/build.gradle
+++ b/packages/p2panda_flutter/android/build.gradle
@@ -23,6 +23,7 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     // Bumping the plugin compileSdkVersion requires all clients of this plugin


### PR DESCRIPTION
Adds Github Action to build apks automatically on every commit to a PR or push do main.

Current error:
```
[!] Your app is using an unsupported Gradle project. To fix this problem, create a new project by running `flutter create -t app <app-directory>` and then move the dart code, assets and pubspec.yaml to the new project.
```