### PR TITLE
fix: update Sighting.update() to update model after query succeeds

### DIFF
--- a/packages/app/lib/models/sightings.dart
+++ b/packages/app/lib/models/sightings.dart
@@ -70,24 +70,25 @@ class Sighting {
       String? comment,
       List<Species>? species,
       List<LocalName>? localNames}) async {
-    Species? updatedSpecies = species?.firstOrNull;
-    LocalName? updatedLocalName = localNames?.firstOrNull;
+    List<DocumentId>? speciesIds;
+    if (species != null) {
+      speciesIds = species.isEmpty ? [] : [species.first.id];
+    }
 
-    this.viewId = await updateSighting(this.viewId,
-        datetime: datetime,
-        latitude: latitude,
-        longitude: longitude,
-        comment: comment,
-        speciesIds: species == null
-            ? null
-            : updatedSpecies == null
-                ? []
-                : [updatedSpecies.id],
-        localNameIds: localNames == null
-            ? null
-            : updatedLocalName == null
-                ? []
-                : [updatedLocalName.id]);
+    List<DocumentId>? localNameIds;
+    if (localNames != null) {
+      localNameIds = localNames.isEmpty ? [] : [localNames.first.id];
+    }
+
+    this.viewId = await updateSighting(
+      this.viewId,
+      datetime: datetime,
+      latitude: latitude,
+      longitude: longitude,
+      comment: comment,
+      speciesIds: speciesIds,
+      localNameIds: localNameIds,
+    );
 
     if (datetime != null) {
       this.datetime = datetime;
@@ -102,11 +103,11 @@ class Sighting {
     }
 
     if (species != null) {
-      this.species = updatedSpecies;
+      this.species = species.firstOrNull;
     }
 
     if (localNames != null) {
-      this.localName = updatedLocalName;
+      this.localName = localNames.firstOrNull;
     }
 
     return this.viewId;

--- a/packages/app/lib/models/sightings.dart
+++ b/packages/app/lib/models/sightings.dart
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import 'dart:ffi';
+
 import 'package:gql/src/ast/ast.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:p2panda_flutter/p2panda_flutter.dart';
@@ -70,6 +72,17 @@ class Sighting {
       String? comment,
       List<Species>? species,
       List<LocalName>? localNames}) async {
+    Species? updatedSpecie = species?.first;
+    LocalName? updatedLocalName = localNames?.first;
+
+    this.viewId = await updateSighting(this.viewId,
+        datetime: datetime,
+        latitude: latitude,
+        longitude: longitude,
+        comment: comment,
+        speciesIds: updatedSpecie == null ? [] : [updatedSpecie.id],
+        localNameIds: updatedLocalName == null ? [] : [updatedLocalName.id]);
+
     if (datetime != null) {
       this.datetime = datetime;
     }
@@ -82,31 +95,13 @@ class Sighting {
       this.longitude = longitude;
     }
 
-    List<DocumentId>? speciesIds;
-    if (species != null && species.isEmpty) {
-      this.species = null;
-      speciesIds = [];
-    } else if (species != null) {
-      this.species = species.first;
-      speciesIds = [species.first.id];
+    if (updatedSpecie != null) {
+      this.species = updatedSpecie;
     }
 
-    List<DocumentId>? localNameIds;
-    if (localNames != null && localNames.isEmpty) {
-      this.localName = null;
-      localNameIds = [];
-    } else if (localNames != null) {
-      this.localName = localNames.first;
-      localNameIds = [localNames.first.id];
+    if (updatedLocalName != null) {
+      this.localName = updatedLocalName;
     }
-
-    this.viewId = await updateSighting(this.viewId,
-        datetime: datetime,
-        latitude: latitude,
-        longitude: longitude,
-        comment: comment,
-        speciesIds: speciesIds,
-        localNameIds: localNameIds);
 
     return this.viewId;
   }

--- a/packages/app/lib/models/sightings.dart
+++ b/packages/app/lib/models/sightings.dart
@@ -95,13 +95,8 @@ class Sighting {
       this.longitude = longitude;
     }
 
-    if (updatedSpecie != null) {
-      this.species = updatedSpecie;
-    }
-
-    if (updatedLocalName != null) {
-      this.localName = updatedLocalName;
-    }
+    this.species = updatedSpecie;
+    this.localName = updatedLocalName;
 
     return this.viewId;
   }

--- a/packages/app/lib/models/sightings.dart
+++ b/packages/app/lib/models/sightings.dart
@@ -80,8 +80,16 @@ class Sighting {
         latitude: latitude,
         longitude: longitude,
         comment: comment,
-        speciesIds: updatedSpecies == null ? [] : [updatedSpecies.id],
-        localNameIds: updatedLocalName == null ? [] : [updatedLocalName.id]);
+        speciesIds: species == null
+            ? null
+            : updatedSpecies == null
+                ? []
+                : [updatedSpecies.id],
+        localNameIds: localNames == null
+            ? null
+            : updatedLocalName == null
+                ? []
+                : [updatedLocalName.id]);
 
     if (datetime != null) {
       this.datetime = datetime;
@@ -95,8 +103,13 @@ class Sighting {
       this.longitude = longitude;
     }
 
-    this.species = updatedSpecies;
-    this.localName = updatedLocalName;
+    if (species != null) {
+      this.species = updatedSpecies;
+    }
+
+    if (localNames != null) {
+      this.localName = updatedLocalName;
+    }
 
     return this.viewId;
   }

--- a/packages/app/lib/models/sightings.dart
+++ b/packages/app/lib/models/sightings.dart
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'dart:ffi';
-
 import 'package:gql/src/ast/ast.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:p2panda_flutter/p2panda_flutter.dart';

--- a/packages/app/lib/models/sightings.dart
+++ b/packages/app/lib/models/sightings.dart
@@ -72,8 +72,8 @@ class Sighting {
       String? comment,
       List<Species>? species,
       List<LocalName>? localNames}) async {
-    Species? updatedSpecie = species?.first;
-    LocalName? updatedLocalName = localNames?.first;
+    Species? updatedSpecie = species?.firstOrNull;
+    LocalName? updatedLocalName = localNames?.firstOrNull;
 
     this.viewId = await updateSighting(this.viewId,
         datetime: datetime,

--- a/packages/app/lib/models/sightings.dart
+++ b/packages/app/lib/models/sightings.dart
@@ -72,7 +72,7 @@ class Sighting {
       String? comment,
       List<Species>? species,
       List<LocalName>? localNames}) async {
-    Species? updatedSpecie = species?.firstOrNull;
+    Species? updatedSpecies = species?.firstOrNull;
     LocalName? updatedLocalName = localNames?.firstOrNull;
 
     this.viewId = await updateSighting(this.viewId,
@@ -80,7 +80,7 @@ class Sighting {
         latitude: latitude,
         longitude: longitude,
         comment: comment,
-        speciesIds: updatedSpecie == null ? [] : [updatedSpecie.id],
+        speciesIds: updatedSpecies == null ? [] : [updatedSpecies.id],
         localNameIds: updatedLocalName == null ? [] : [updatedLocalName.id]);
 
     if (datetime != null) {
@@ -95,7 +95,7 @@ class Sighting {
       this.longitude = longitude;
     }
 
-    this.species = updatedSpecie;
+    this.species = updatedSpecies;
     this.localName = updatedLocalName;
 
     return this.viewId;


### PR DESCRIPTION
Originally `Sighting.update()` updates the model optimistically without any way to revert the change if the query failed. This makes sure the query succeeds before updating the model at all.

