### PR TITLE
fix: use correct edit icon for notes field

### DIFF
--- a/packages/app/lib/ui/widgets/note_field.dart
+++ b/packages/app/lib/ui/widgets/note_field.dart
@@ -63,12 +63,13 @@ class _NoteFieldState extends State<NoteField> {
               title: t.noteCardTitle,
               icon: _inputMode == InputMode.read
                   ? CardActionButton(
-                      icon: const Icon(Icons.edit),
+                      icon: const Icon(Icons.edit_outlined),
                       onPressed: _handleStartEditMode,
                     )
                   : null),
           Container(
-              padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 6.0),
+              padding:
+                  const EdgeInsets.symmetric(vertical: 10.0, horizontal: 6.0),
               alignment: AlignmentDirectional.centerStart,
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -79,7 +80,8 @@ class _NoteFieldState extends State<NoteField> {
                   // being false when in 'read' input mode
                   TextFormField(
                       controller: _textInputController,
-                      decoration: const InputDecoration(border: OutlineInputBorder()),
+                      decoration:
+                          const InputDecoration(border: OutlineInputBorder()),
                       focusNode: _textInputFocusNode,
                       keyboardType: TextInputType.multiline,
                       maxLines: null,


### PR DESCRIPTION
Not sure how this one got past me 😅 

---

Before:

<img width="300" alt="image" src="https://github.com/p2panda/meli/assets/18542095/9bdb38e3-3b28-4939-afff-3be60fc6f056">


After:

<img width="300" alt="image" src="https://github.com/p2panda/meli/assets/18542095/cdd4a872-dd76-468f-88ad-19d3b75b616a">
