### PR TITLE
fix: fix population of longitude field in Sighting.fromJson()

### DIFF
--- a/packages/app/lib/models/sightings.dart
+++ b/packages/app/lib/models/sightings.dart
@@ -56,7 +56,7 @@ class Sighting {
         viewId: result['meta']['viewId'] as DocumentViewId,
         datetime: DateTime.parse(result['fields']['datetime'] as String),
         latitude: result['fields']['latitude'] as double,
-        longitude: result['fields']['latitude'] as double,
+        longitude: result['fields']['longitude'] as double,
         comment: result['fields']['comment'] as String,
         images: images,
         species: species.firstOrNull,


### PR DESCRIPTION
`longitude` field was incorrectly being populated with latitude instead of longitude