### PR TITLE
chore: update android build configuration to use variants properly

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -34,8 +34,8 @@ jobs:
         run: melos build
       - name: Build APK
         working-directory: ./packages/app
-        run: flutter build apk
+        run: flutter build apk --flavor qa
       - uses: actions/upload-artifact@v4
         with:
-          name: app-release
-          path: packages/app/build/app/outputs/flutter-apk/app-release.apk
+          name: app-qa-release
+          path: packages/app/build/app/outputs/flutter-apk/app-qa-release.apk

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ flutter emulators --launch <id>
 flutter devices
 
 # Run app on emulated or connected device
-flutter run --device-id <id>
+flutter run --flavor normal --device-id <id>
 ```
 
 ### Relay Node

--- a/packages/app/android/app/build.gradle
+++ b/packages/app/android/app/build.gradle
@@ -51,13 +51,44 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        manifestPlaceholders = [applicationLabel: "Meli"]
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+            debuggable true
+            manifestPlaceholders = [applicationLabel: "Meli (Debug)"]
+        }
+        profile {
+            applicationIdSuffix ".profile"
+            manifestPlaceholders = [applicationLabel: "Meli (Profile)"]
+        }
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+        }
+    }
+
+    flavorDimensions "appType"
+
+    productFlavors {
+        normal {
+            dimension "appType"
+        }
+        qa {
+            dimension "appType"
+            applicationIdSuffix ".qa"
+            manifestPlaceholders = [applicationLabel: "Meli (QA)"]
+        }
+    }
+
+    variantFilter { variant ->
+        def names = variant.flavors*.name
+        // Skip qa flavor for debug and profile builds
+        if (names.contains('qa') && (variant.buildType.name == "debug" || variant.buildType.name == "profile")) {
+            setIgnore(true)
         }
     }
 }

--- a/packages/app/android/app/src/main/AndroidManifest.xml
+++ b/packages/app/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <application
-        android:label="Meli"
-        android:name="${applicationName}"
+        android:label="${applicationLabel}"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
Introduces the following changes:

- Adds application id suffixes based on build type (e.g. debug, profile, release) and flavor (e.g. normal, qa). This allows you have these installed as separate apps on the same device e.g. installing a QA release of an app will not override an existing normal release app.

    - for existing contributors, this means that you've worked with the debug build in development, running `flutter run --flavor normal` will result in a different app being installed, meaning that the data you've accumulated on the pre-existing debug build will not be accessible to this new debug build. 

- Updates the app label based on build type and flavor, to make it easier to know which one is installed on the device. for example, if you installed every valid combination, you'll have something like this, where each app is isolated from each other:

    <img width="218" alt="image" src="https://github.com/p2panda/meli/assets/18542095/c1da2c49-6651-4ad0-a197-dd0291120ade">

- Introduces [product flavors](https://developer.android.com/build/build-variants#product-flavors): `normal` and `qa`. This is mostly for the case of being able to differentiate between production release build and qa release build. the `qa` flavor does not apply to debug and profile build types, and trying to create an apk with that combination will fail to work (the error message provided by gradle + flutter is not the clearest).

    - this introduces a small annoyance: for the sake of flutter, it's important to be explicit about the flavor you want to build/run. for example, instead of just running `flutter run`, you'll have to do something like `flutter run --flavor normal` in order for flutter to perform the expected behavior (i.e. building the debug apk and then loading it onto the device/emulator). if the `--flavor` is not specified for commands such as `flutter run` or `flutter build`, flutter/gradle will still build the apk(s) but will build one for each flavor that's enabled for a build type (e.g. `release + qa` and `release + normal`). In this case, you'll get a log that looks like this upon completion: 
    
        ```
        Error: Gradle build failed to produce an .apk file. It's likely that this file was generated under /Users/andrewchou/GitHub/p2panda/meli/packages/app/build, but the tool couldn't find it.
        ```