### PR TITLE
Wait until data got changed and refresh widgets before returning to previous screens

### DIFF
--- a/packages/app/lib/app.dart
+++ b/packages/app/lib/app.dart
@@ -5,9 +5,10 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:app/io/graphql/graphql.dart' as graphql;
 import 'package:app/router.dart';
 import 'package:app/ui/widgets/image_provider.dart';
-import 'package:app/io/graphql/graphql.dart' as graphql;
+import 'package:app/ui/widgets/refresh_provider.dart';
 
 class MeliApp extends StatefulWidget {
   const MeliApp({super.key});
@@ -50,7 +51,8 @@ class MeliAppState extends State<MeliApp> {
 
     return GraphQLProvider(
         client: client,
-        child: MeliCameraProvider(MaterialApp.router(
+        child: RefreshProvider(
+            child: MeliCameraProvider(MaterialApp.router(
           // Register router for navigation
           routerDelegate: router.routerDelegate,
           routeInformationProvider: router.routeInformationProvider,
@@ -73,6 +75,6 @@ class MeliAppState extends State<MeliApp> {
 
           // Disable "debug" banner shown in top right corner during development
           debugShowCheckedModeBanner: false,
-        )));
+        ))));
   }
 }

--- a/packages/app/lib/io/p2panda/schemas.dart
+++ b/packages/app/lib/io/p2panda/schemas.dart
@@ -107,7 +107,7 @@ Future<bool> isDocumentViewAvailable(
     SchemaId schemaId, DocumentViewId viewId) async {
   String query = '''
     query CheckDocumentStatus() {
-      status: all_$schemaId(meta: { viewId: "$viewId" }) {
+      status: all_$schemaId(meta: { viewId: { eq: "$viewId" } }) {
         totalCount
       }
     }

--- a/packages/app/lib/io/p2panda/schemas.dart
+++ b/packages/app/lib/io/p2panda/schemas.dart
@@ -116,12 +116,12 @@ Future<bool> isDocumentViewAvailable(
   final options = QueryOptions(document: gql(query));
   final result = await client.query(options);
 
-  if (!result.hasException) {
-    final status = result.data?['status'] as Map<String, dynamic>;
-    return status['totalCount'] == 1;
+  if (result.hasException) {
+    throw "Error while querying if document view was materialized on node";
   }
 
-  return false;
+  final status = result.data?['status'] as Map<String, dynamic>;
+  return status['totalCount'] == 1;
 }
 
 /// Async helper method to block until node materialized schemas and updated

--- a/packages/app/lib/router.dart
+++ b/packages/app/lib/router.dart
@@ -34,7 +34,7 @@ final router = GoRouter(routes: [
   // app logic running yet while everything else is bootstrapping.
   _Route(RoutePaths.splash, (_) => Container(color: Colors.white)),
   _Route(RoutePaths.settings, (_) => const SettingsScreen()),
-  _Route(RoutePaths.allSightings, (_) => const AllSightingsScreen()),
+  _Route(RoutePaths.allSightings, (_) => AllSightingsScreen()),
   _Route(RoutePaths.allSpecies, (_) => AllSpeciesScreen()),
   _Route(
       RoutePaths.sighting,

--- a/packages/app/lib/ui/screens/all_sightings.dart
+++ b/packages/app/lib/ui/screens/all_sightings.dart
@@ -31,8 +31,10 @@ class AllSightingsScreen extends StatelessWidget {
             onPressed: () {
               router.push(RoutePaths.createSighting.path).then((value) {
                 // Refresh list after returning from creating a new sighting
-                if (paginator.refresh != null) {
-                  paginator.refresh!();
+                if (value == true) {
+                  if (paginator.refresh != null) {
+                    paginator.refresh!();
+                  }
                 }
               });
             }),

--- a/packages/app/lib/ui/screens/all_sightings.dart
+++ b/packages/app/lib/ui/screens/all_sightings.dart
@@ -11,7 +11,9 @@ import 'package:app/ui/widgets/scaffold.dart';
 import 'package:app/ui/widgets/sightings_list.dart';
 
 class AllSightingsScreen extends StatelessWidget {
-  const AllSightingsScreen({super.key});
+  final Paginator<Sighting> paginator = SightingPaginator();
+
+  AllSightingsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -27,7 +29,12 @@ class AllSightingsScreen extends StatelessWidget {
             icon: const Icon(Icons.camera_alt_outlined),
             backgroundColor: MeliColors.sea,
             onPressed: () {
-              router.push(RoutePaths.createSighting.path);
+              router.push(RoutePaths.createSighting.path).then((value) {
+                // Refresh list after returning from creating a new sighting
+                if (paginator.refresh != null) {
+                  paginator.refresh!();
+                }
+              });
             }),
       ],
       body: Container(
@@ -35,16 +42,16 @@ class AllSightingsScreen extends StatelessWidget {
           child: Container(
             padding:
                 EdgeInsets.only(top: MediaQuery.of(context).viewPadding.top),
-            child: ScrollView(),
+            child: ScrollView(paginator: paginator),
           )),
     );
   }
 }
 
 class ScrollView extends StatelessWidget {
-  final Paginator<Sighting> paginator = SightingPaginator();
+  final Paginator<Sighting> paginator;
 
-  ScrollView({super.key});
+  const ScrollView({super.key, required this.paginator});
 
   @override
   Widget build(BuildContext context) {
@@ -64,7 +71,8 @@ class ScrollView extends StatelessWidget {
             const BouncyBee(),
             const SizedBox(height: 30.0),
             Container(
-                padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 20.0),
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 20.0, vertical: 20.0),
                 decoration: const MagnoliaWavesBackground(),
                 child: Container(
                     width: double.infinity,

--- a/packages/app/lib/ui/screens/all_sightings.dart
+++ b/packages/app/lib/ui/screens/all_sightings.dart
@@ -7,6 +7,7 @@ import 'package:app/models/sightings.dart';
 import 'package:app/router.dart';
 import 'package:app/ui/colors.dart';
 import 'package:app/ui/widgets/fab.dart';
+import 'package:app/ui/widgets/refresh_provider.dart';
 import 'package:app/ui/widgets/scaffold.dart';
 import 'package:app/ui/widgets/sightings_list.dart';
 
@@ -31,10 +32,10 @@ class AllSightingsScreen extends StatelessWidget {
             onPressed: () {
               router.push(RoutePaths.createSighting.path).then((value) {
                 // Refresh list after returning from creating a new sighting
-                if (value == true) {
-                  if (paginator.refresh != null) {
-                    paginator.refresh!();
-                  }
+                if (RefreshProvider.of(context)
+                        .isDirty(RefreshKeys.CreatedSighting) &&
+                    paginator.refresh != null) {
+                  paginator.refresh!();
                 }
               });
             }),

--- a/packages/app/lib/ui/screens/all_species.dart
+++ b/packages/app/lib/ui/screens/all_species.dart
@@ -59,7 +59,12 @@ class _SpeciesListState extends State<SpeciesList> {
     return SpeciesCard(
         onTap: () => {
               router.pushNamed(RoutePaths.species.name,
-                  pathParameters: {'documentId': species.id})
+                  pathParameters: {'documentId': species.id}).then((value) {
+                // Refresh list after returning from updating a species
+                if (widget.paginator.refresh != null) {
+                  widget.paginator.refresh!();
+                }
+              })
             },
         taxonomySpecies: species.species,
         id: species.id);

--- a/packages/app/lib/ui/screens/all_species.dart
+++ b/packages/app/lib/ui/screens/all_species.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'package:app/ui/widgets/pagination_list.dart';
+import 'package:app/ui/widgets/refresh_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -61,7 +62,9 @@ class _SpeciesListState extends State<SpeciesList> {
               router.pushNamed(RoutePaths.species.name,
                   pathParameters: {'documentId': species.id}).then((value) {
                 // Refresh list after returning from updating a species
-                if (widget.paginator.refresh != null) {
+                if (RefreshProvider.of(context)
+                        .isDirty(RefreshKeys.UpdatedSpecies) &&
+                    widget.paginator.refresh != null) {
                   widget.paginator.refresh!();
                 }
               })

--- a/packages/app/lib/ui/screens/create_sighting.dart
+++ b/packages/app/lib/ui/screens/create_sighting.dart
@@ -135,8 +135,9 @@ class _CreateSightingScreenState extends State<CreateSightingScreen> {
       // .. wait until sighting got materialized on node
       await untilDocumentViewAvailable(SchemaIds.bee_sighting, viewId);
 
-      // Go back to sightings overview
-      router.pop();
+      // Go back to sightings overview (use "replace" instead of "pop" method to
+      // force re-rendering of screen, to make sure it shows the new item)
+      router.pushReplacementNamed(RoutePaths.allSightings.name);
 
       // Show notification
       messenger.showSnackBar(SnackBar(

--- a/packages/app/lib/ui/screens/create_sighting.dart
+++ b/packages/app/lib/ui/screens/create_sighting.dart
@@ -135,9 +135,8 @@ class _CreateSightingScreenState extends State<CreateSightingScreen> {
       // .. wait until sighting got materialized on node
       await untilDocumentViewAvailable(SchemaIds.bee_sighting, viewId);
 
-      // Go back to sightings overview (use "replace" instead of "pop" method to
-      // force re-rendering of screen, to make sure it shows the new item)
-      router.pushReplacementNamed(RoutePaths.allSightings.name);
+      // Go back to sightings overview
+      router.pop();
 
       // Show notification
       messenger.showSnackBar(SnackBar(

--- a/packages/app/lib/ui/screens/create_sighting.dart
+++ b/packages/app/lib/ui/screens/create_sighting.dart
@@ -136,7 +136,7 @@ class _CreateSightingScreenState extends State<CreateSightingScreen> {
       await untilDocumentViewAvailable(SchemaIds.bee_sighting, viewId);
 
       // Go back to sightings overview
-      router.pop();
+      router.pop(true);
 
       // Show notification
       messenger.showSnackBar(SnackBar(
@@ -171,7 +171,7 @@ class _CreateSightingScreenState extends State<CreateSightingScreen> {
         _addImage(file);
       } else {
         // If no file was captured navigate back to all sightings screen
-        router.pop();
+        router.pop(false);
       }
     });
   }

--- a/packages/app/lib/ui/screens/create_sighting.dart
+++ b/packages/app/lib/ui/screens/create_sighting.dart
@@ -6,8 +6,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:app/io/p2panda/publish.dart';
+import 'package:app/io/p2panda/schemas.dart';
 import 'package:app/models/blobs.dart';
 import 'package:app/models/local_names.dart';
+import 'package:app/models/schema_ids.dart';
 import 'package:app/models/sightings.dart';
 import 'package:app/router.dart';
 import 'package:app/ui/colors.dart';
@@ -22,7 +24,6 @@ import 'package:app/ui/widgets/local_name_autocomplete.dart';
 import 'package:app/ui/widgets/location_tracker.dart';
 import 'package:app/ui/widgets/scaffold.dart';
 import 'package:app/ui/widgets/simple_card.dart';
-import 'package:app/utils/sleep.dart';
 
 const String PLACEHOLDER_IMG = 'assets/images/placeholder-bee.png';
 
@@ -124,15 +125,15 @@ class _CreateSightingScreenState extends State<CreateSightingScreen> {
       }
 
       // Publish the sighting
-      await createSighting(
+      final viewId = await createSighting(
           datetime: datetime,
           latitude: latitude,
           longitude: longitude,
           imageIds: imageIds,
           localNameIds: localNameIds);
 
-      // .. wait a little bit
-      await sleep(500);
+      // .. wait until sighting got materialized on node
+      await untilDocumentViewAvailable(SchemaIds.bee_sighting, viewId);
 
       // Go back to sightings overview
       router.pop();

--- a/packages/app/lib/ui/screens/create_sighting.dart
+++ b/packages/app/lib/ui/screens/create_sighting.dart
@@ -2,6 +2,7 @@
 
 import 'dart:io';
 
+import 'package:app/ui/widgets/refresh_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -101,6 +102,7 @@ class _CreateSightingScreenState extends State<CreateSightingScreen> {
   void _createSighting() async {
     final messenger = ScaffoldMessenger.of(context);
     final t = AppLocalizations.of(context)!;
+    final refreshProvider = RefreshProvider.of(context);
 
     _overlayKey.currentState!.show();
 
@@ -135,8 +137,12 @@ class _CreateSightingScreenState extends State<CreateSightingScreen> {
       // .. wait until sighting got materialized on node
       await untilDocumentViewAvailable(SchemaIds.bee_sighting, viewId);
 
+      // Set flag to indicate to other widgets that they need to refresh their
+      // data to include this new sighting in their listings
+      refreshProvider.setDirty(RefreshKeys.CreatedSighting);
+
       // Go back to sightings overview
-      router.pop(true);
+      router.pop();
 
       // Show notification
       messenger.showSnackBar(SnackBar(
@@ -171,7 +177,7 @@ class _CreateSightingScreenState extends State<CreateSightingScreen> {
         _addImage(file);
       } else {
         // If no file was captured navigate back to all sightings screen
-        router.pop(false);
+        router.pop();
       }
     });
   }

--- a/packages/app/lib/ui/screens/species.dart
+++ b/packages/app/lib/ui/screens/species.dart
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'package:app/ui/widgets/species_local_names_aggregate.dart';
-import 'package:app/ui/widgets/species_uses_aggregate.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
@@ -11,11 +9,14 @@ import 'package:app/models/base.dart';
 import 'package:app/models/sightings.dart';
 import 'package:app/models/species.dart';
 import 'package:app/models/taxonomy_species.dart';
+import 'package:app/router.dart';
 import 'package:app/ui/colors.dart';
 import 'package:app/ui/widgets/error_card.dart';
 import 'package:app/ui/widgets/scaffold.dart';
 import 'package:app/ui/widgets/sightings_tiles.dart';
 import 'package:app/ui/widgets/species_field.dart';
+import 'package:app/ui/widgets/species_local_names_aggregate.dart';
+import 'package:app/ui/widgets/species_uses_aggregate.dart';
 import 'package:app/ui/widgets/text_field.dart';
 
 class SpeciesScreen extends StatefulWidget {
@@ -28,6 +29,8 @@ class SpeciesScreen extends StatefulWidget {
 }
 
 class _SpeciesScreenState extends State<SpeciesScreen> {
+  VoidCallback? refetch;
+
   @override
   Widget build(BuildContext context) {
     return MeliScaffold(
@@ -37,6 +40,8 @@ class _SpeciesScreenState extends State<SpeciesScreen> {
             options:
                 QueryOptions(document: gql(speciesQuery(widget.documentId))),
             builder: (result, {VoidCallback? refetch, FetchMore? fetchMore}) {
+              this.refetch = refetch;
+
               if (result.hasException) {
                 return ErrorCard(message: result.exception.toString());
               }
@@ -54,15 +59,16 @@ class _SpeciesScreenState extends State<SpeciesScreen> {
               final species = Species.fromJson(
                   result.data?['species'] as Map<String, dynamic>);
 
-              return SpeciesProfile(species);
+              return SpeciesProfile(species, refetch);
             }));
   }
 }
 
 class SpeciesProfile extends StatefulWidget {
   final Species initialValue;
+  final VoidCallback? refetch;
 
-  const SpeciesProfile(this.initialValue, {super.key});
+  const SpeciesProfile(this.initialValue, this.refetch, {super.key});
 
   @override
   State<SpeciesProfile> createState() => _SpeciesProfileState();
@@ -119,7 +125,19 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
             SpeciesLocalNamesAggregate(id: species.id),
             const SizedBox(height: 20.0),
           ])),
-          RelatedSightings(id: species.id),
+          RelatedSightings(
+              id: species.id,
+              onTap: (DocumentId sightingId) {
+                router.pushNamed(RoutePaths.sighting.name,
+                    pathParameters: {'documentId': sightingId}).then((value) {
+                  // Force loading the species again after we've returned from
+                  // an updated sighting, to make sure that aggregated data over
+                  // all sightings is up-to-date
+                  if (widget.refetch != null) {
+                    widget.refetch!();
+                  }
+                });
+              }),
           const SliverToBoxAdapter(child: SizedBox(height: 20.0)),
         ],
       ),
@@ -127,15 +145,18 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
   }
 }
 
+typedef OnTap = Function(DocumentId id);
+
 class RelatedSightings extends StatelessWidget {
   final DocumentId id;
+  final OnTap onTap;
 
-  const RelatedSightings({super.key, required this.id});
+  const RelatedSightings({super.key, required this.id, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
     final Paginator<Sighting> paginator = SpeciesSightingsPaginator(id);
-    return SightingsTiles(paginator: paginator);
+    return SightingsTiles(paginator: paginator, onTap: onTap);
   }
 }
 

--- a/packages/app/lib/ui/screens/species.dart
+++ b/packages/app/lib/ui/screens/species.dart
@@ -12,6 +12,7 @@ import 'package:app/models/taxonomy_species.dart';
 import 'package:app/router.dart';
 import 'package:app/ui/colors.dart';
 import 'package:app/ui/widgets/error_card.dart';
+import 'package:app/ui/widgets/refresh_provider.dart';
 import 'package:app/ui/widgets/scaffold.dart';
 import 'package:app/ui/widgets/sightings_tiles.dart';
 import 'package:app/ui/widgets/species_field.dart';
@@ -84,12 +85,19 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
     super.initState();
   }
 
+  void _setUpdateFlag() {
+    // Set flag for other widgets to tell them that they might need to re-render
+    // their data. This will make sure that our updates are reflected in the UI
+    RefreshProvider.of(context).setDirty(RefreshKeys.UpdatedSpecies);
+  }
+
   Future<void> _updateTaxon(TaxonomySpecies? taxon) async {
     if (species.species.id == taxon?.id) {
       // Nothing has changed
       return;
     } else if (taxon != null) {
       await species.update(species: taxon);
+      _setUpdateFlag();
       setState(() {});
     }
   }
@@ -133,7 +141,9 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
                   // Force loading the species again after we've returned from
                   // an updated sighting, to make sure that aggregated data over
                   // all sightings is up-to-date
-                  if (widget.refetch != null) {
+                  if (RefreshProvider.of(context)
+                          .isDirty(RefreshKeys.UpdatedSighting) &&
+                      widget.refetch != null) {
                     widget.refetch!();
                   }
                 });

--- a/packages/app/lib/ui/screens/species.dart
+++ b/packages/app/lib/ui/screens/species.dart
@@ -145,7 +145,7 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
   }
 }
 
-typedef OnTap = Function(DocumentId id);
+typedef OnTap = void Function(DocumentId id);
 
 class RelatedSightings extends StatelessWidget {
   final DocumentId id;

--- a/packages/app/lib/ui/widgets/hive_location_field.dart
+++ b/packages/app/lib/ui/widgets/hive_location_field.dart
@@ -18,10 +18,13 @@ const GROUND_ICON = Icons.grass;
 const TREE_ICON = Icons.park;
 
 class HiveLocationField extends StatefulWidget {
+  final VoidCallback onUpdate;
+
   /// Document id of the sighting we're managing the location for.
   final DocumentId sightingId;
 
-  const HiveLocationField({super.key, required this.sightingId});
+  const HiveLocationField(
+      {super.key, required this.sightingId, required this.onUpdate});
 
   @override
   State<HiveLocationField> createState() => _HiveLocationFieldState();
@@ -77,10 +80,12 @@ class _HiveLocationFieldState extends State<HiveLocationField> {
                   initialValue: location,
                   sightingId: widget.sightingId,
                   isEditMode: isEditMode,
-                  onUpdated: () {
+                  onUpdate: () {
                     setState(() {
                       isEditMode = false;
                     });
+
+                    widget.onUpdate();
                   });
             }));
   }
@@ -91,14 +96,14 @@ class HiveLocationFieldInner extends StatefulWidget {
   final DocumentId sightingId;
 
   final bool isEditMode;
-  final VoidCallback onUpdated;
+  final VoidCallback onUpdate;
 
   const HiveLocationFieldInner(
       {super.key,
       required this.initialValue,
       required this.sightingId,
       required this.isEditMode,
-      required this.onUpdated});
+      required this.onUpdate});
 
   @override
   State<HiveLocationFieldInner> createState() => _HiveLocationFieldInnerState();
@@ -144,7 +149,7 @@ class _HiveLocationFieldInnerState extends State<HiveLocationFieldInner> {
     }
 
     setState(() {});
-    widget.onUpdated();
+    widget.onUpdate();
   }
 
   @override
@@ -152,9 +157,9 @@ class _HiveLocationFieldInnerState extends State<HiveLocationFieldInner> {
     if (widget.isEditMode) {
       return HiveLocationFieldEdit(
           location: location,
-          onUpdated: _handleUpdate,
+          onUpdate: _handleUpdate,
           onCancelled: () {
-            widget.onUpdated();
+            widget.onUpdate();
           });
     }
 
@@ -235,18 +240,18 @@ class HiveLocationFieldShow extends StatelessWidget {
   }
 }
 
-typedef OnUpdated = void Function(
+typedef OnUpdate = void Function(
     LocationType? type, String? species, double? height, double? diameter);
 
 class HiveLocationFieldEdit extends StatefulWidget {
   final Location? location;
-  final OnUpdated onUpdated;
+  final OnUpdate onUpdate;
   final Function onCancelled;
 
   const HiveLocationFieldEdit(
       {super.key,
       required this.location,
-      required this.onUpdated,
+      required this.onUpdate,
       required this.onCancelled});
 
   @override
@@ -276,11 +281,11 @@ class _HiveLocationFieldEditState extends State<HiveLocationFieldEdit> {
 
   void _handleSave() {
     if (type == LocationType.Tree) {
-      widget.onUpdated(type, treeSpecies, height, diameter);
+      widget.onUpdate(type, treeSpecies, height, diameter);
     } else if (type == null) {
-      widget.onUpdated(null, null, null, null);
+      widget.onUpdate(null, null, null, null);
     } else {
-      widget.onUpdated(type, null, null, null);
+      widget.onUpdate(type, null, null, null);
     }
   }
 
@@ -296,7 +301,7 @@ class _HiveLocationFieldEditState extends State<HiveLocationFieldEdit> {
               treeSpecies: treeSpecies,
               height: height,
               diameter: diameter,
-              onUpdated: (treeSpecies, height, diameter) {
+              onUpdate: (treeSpecies, height, diameter) {
                 setState(() {
                   this.treeSpecies = treeSpecies;
                   this.height = height;
@@ -313,7 +318,7 @@ class _HiveLocationFieldEditState extends State<HiveLocationFieldEdit> {
     return Column(children: [
       HiveLocationTypeSelector(
         locationType: type,
-        onUpdated: (LocationType? locationType) {
+        onUpdate: (LocationType? locationType) {
           setState(() {
             type = locationType;
           });
@@ -336,14 +341,14 @@ class HiveTreeLocationEdit extends StatelessWidget {
   final double? diameter;
   final double? height;
 
-  final OnTreeUpdated onUpdated;
+  final OnTreeUpdated onUpdate;
 
   const HiveTreeLocationEdit(
       {super.key,
       required this.treeSpecies,
       required this.diameter,
       required this.height,
-      required this.onUpdated});
+      required this.onUpdate});
 
   Widget _label(String title, double? value) {
     if (value == null) {
@@ -390,7 +395,7 @@ class HiveTreeLocationEdit extends StatelessWidget {
             ),
           ),
           onChanged: (String value) {
-            onUpdated(value, height, diameter);
+            onUpdate(value, height, diameter);
           }),
       _label(t.hiveLocationTreeHeight, height),
       SliderTheme(
@@ -403,7 +408,7 @@ class HiveTreeLocationEdit extends StatelessWidget {
           divisions: 100,
           value: height != null ? height! : 0.0,
           onChanged: (double value) {
-            onUpdated(treeSpecies, value.roundToDouble(), diameter);
+            onUpdate(treeSpecies, value.roundToDouble(), diameter);
           },
         ),
       ),
@@ -418,7 +423,7 @@ class HiveTreeLocationEdit extends StatelessWidget {
           divisions: 20,
           value: diameter != null ? diameter! : 0.0,
           onChanged: (double value) {
-            onUpdated(treeSpecies, height, value);
+            onUpdate(treeSpecies, height, value);
           },
         ),
       ),
@@ -430,16 +435,16 @@ typedef OnTypeUpdated = void Function(LocationType? locationType);
 
 class HiveLocationTypeSelector extends StatelessWidget {
   final LocationType? locationType;
-  final OnTypeUpdated onUpdated;
+  final OnTypeUpdated onUpdate;
 
   const HiveLocationTypeSelector(
-      {super.key, required this.locationType, required this.onUpdated});
+      {super.key, required this.locationType, required this.onUpdate});
 
   void _onToggle(LocationType value) {
     if (locationType == value) {
-      onUpdated(null);
+      onUpdate(null);
     } else {
-      onUpdated(value);
+      onUpdate(value);
     }
   }
 

--- a/packages/app/lib/ui/widgets/image_provider.dart
+++ b/packages/app/lib/ui/widgets/image_provider.dart
@@ -3,7 +3,6 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-
 import 'package:image_picker/image_picker.dart';
 
 class MeliCameraProvider extends StatefulWidget {

--- a/packages/app/lib/ui/widgets/refresh_provider.dart
+++ b/packages/app/lib/ui/widgets/refresh_provider.dart
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:flutter/widgets.dart';
+
+enum RefreshKeys {
+  /// New sighting got created which might affect other views.
+  CreatedSighting,
+
+  /// Sighting got updated with data which might affect other views.
+  UpdatedSighting,
+
+  /// Species got updated with data which might affect other views.
+  UpdatedSpecies,
+}
+
+/// Global state keeping track of events where data was changed or created. This
+/// is a way to inform widgets somewhere else in the app that they'll need to
+/// reload data from the node and re-render as things have changed.
+class RefreshProvider extends InheritedWidget {
+  final Map<RefreshKeys, bool> _map = {};
+
+  RefreshProvider({
+    super.key,
+    required super.child,
+  });
+
+  /// Flip dirty flag.
+  void setDirty(RefreshKeys key) {
+    _map[key] = true;
+  }
+
+  /// Returns status of "dirty" flag and flips it to false afterwards.
+  bool isDirty(RefreshKeys key) {
+    if (!_map.containsKey(key)) {
+      return false;
+    }
+
+    bool status = _map[key]!;
+    _map[key] = false;
+    return status;
+  }
+
+  static RefreshProvider of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<RefreshProvider>()!;
+  }
+
+  @override
+  bool updateShouldNotify(RefreshProvider oldWidget) {
+    return false;
+  }
+}

--- a/packages/app/lib/ui/widgets/sightings_list.dart
+++ b/packages/app/lib/ui/widgets/sightings_list.dart
@@ -21,7 +21,12 @@ class _SightingsListState extends State<SightingsList> {
   Widget _item(Sighting sighting) {
     return SightingCard(
         onTap: () => router.pushNamed(RoutePaths.sighting.name,
-            pathParameters: {'documentId': sighting.id}),
+                pathParameters: {'documentId': sighting.id}).then((value) {
+              // Refresh list when we've returned from updating the sighting
+              if (widget.paginator.refresh != null) {
+                widget.paginator.refresh!();
+              }
+            }),
         date: sighting.datetime,
         localName: sighting.localName,
         species: sighting.species,

--- a/packages/app/lib/ui/widgets/sightings_list.dart
+++ b/packages/app/lib/ui/widgets/sightings_list.dart
@@ -6,6 +6,7 @@ import 'package:app/models/base.dart';
 import 'package:app/models/sightings.dart';
 import 'package:app/router.dart';
 import 'package:app/ui/widgets/pagination_list.dart';
+import 'package:app/ui/widgets/refresh_provider.dart';
 import 'package:app/ui/widgets/sighting_card.dart';
 
 class SightingsList extends StatefulWidget {
@@ -22,8 +23,10 @@ class _SightingsListState extends State<SightingsList> {
     return SightingCard(
         onTap: () => router.pushNamed(RoutePaths.sighting.name,
                 pathParameters: {'documentId': sighting.id}).then((value) {
-              // Refresh list when we've returned from updating the sighting
-              if (widget.paginator.refresh != null) {
+              // Refresh list when we've returned from updating a sighting
+              if (RefreshProvider.of(context)
+                      .isDirty(RefreshKeys.UpdatedSighting) &&
+                  widget.paginator.refresh != null) {
                 widget.paginator.refresh!();
               }
             }),

--- a/packages/app/lib/ui/widgets/sightings_tiles.dart
+++ b/packages/app/lib/ui/widgets/sightings_tiles.dart
@@ -7,14 +7,17 @@ import 'package:app/models/blobs.dart';
 import 'package:app/models/sightings.dart';
 import 'package:app/router.dart';
 import 'package:app/ui/colors.dart';
+import 'package:app/ui/screens/species.dart';
 import 'package:app/ui/widgets/card.dart';
 import 'package:app/ui/widgets/image.dart';
 import 'package:app/ui/widgets/pagination_list.dart';
 
 class SightingsTiles extends StatefulWidget {
   final Paginator<Sighting> paginator;
+  final OnTap onTap;
 
-  const SightingsTiles({super.key, required this.paginator});
+  const SightingsTiles(
+      {super.key, required this.paginator, required this.onTap});
 
   @override
   State<SightingsTiles> createState() => _SightingsTilesState();
@@ -23,8 +26,7 @@ class SightingsTiles extends StatefulWidget {
 class _SightingsTilesState extends State<SightingsTiles> {
   Widget _item(Sighting sighting) {
     return SightingTile(
-        onTap: () => router.pushNamed(RoutePaths.sighting.name,
-            pathParameters: {'documentId': sighting.id}),
+        onTap: () => widget.onTap(sighting.id),
         date: sighting.datetime,
         image: sighting.images.firstOrNull);
   }

--- a/packages/app/lib/ui/widgets/sightings_tiles.dart
+++ b/packages/app/lib/ui/widgets/sightings_tiles.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:app/models/base.dart';
 import 'package:app/models/blobs.dart';
 import 'package:app/models/sightings.dart';
-import 'package:app/router.dart';
 import 'package:app/ui/colors.dart';
 import 'package:app/ui/screens/species.dart';
 import 'package:app/ui/widgets/card.dart';

--- a/packages/app/lib/ui/widgets/species_local_names_aggregate.dart
+++ b/packages/app/lib/ui/widgets/species_local_names_aggregate.dart
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'package:app/models/local_names.dart';
-import 'package:app/ui/widgets/local_names_dedup_tag_list.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:flutter/material.dart';
 
 import 'package:app/io/p2panda/publish.dart';
-import 'package:app/ui/widgets/tag_item.dart';
+import 'package:app/models/local_names.dart';
 import 'package:app/ui/widgets/card.dart';
 import 'package:app/ui/widgets/card_header.dart';
+import 'package:app/ui/widgets/local_names_dedup_tag_list.dart';
+import 'package:app/ui/widgets/tag_item.dart';
 
 class SpeciesLocalNamesAggregate extends StatelessWidget {
   final DocumentId id;

--- a/packages/app/lib/ui/widgets/species_uses_aggregate.dart
+++ b/packages/app/lib/ui/widgets/species_uses_aggregate.dart
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'package:app/ui/widgets/pagination_list.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:flutter/material.dart';
 
 import 'package:app/io/p2panda/publish.dart';
 import 'package:app/models/sightings.dart';
 import 'package:app/models/used_for.dart';
-import 'package:app/ui/widgets/tag_item.dart';
-import 'package:app/ui/widgets/used_for_dedup_tag_list.dart';
 import 'package:app/ui/widgets/card.dart';
 import 'package:app/ui/widgets/card_header.dart';
+import 'package:app/ui/widgets/pagination_list.dart';
+import 'package:app/ui/widgets/tag_item.dart';
+import 'package:app/ui/widgets/used_for_dedup_tag_list.dart';
 
 class SpeciesUsesAggregate extends StatelessWidget {
   final DocumentId id;

--- a/packages/app/lib/ui/widgets/used_for_field.dart
+++ b/packages/app/lib/ui/widgets/used_for_field.dart
@@ -20,8 +20,10 @@ typedef OnUpdate = Future<DocumentViewId> Function(String);
 
 class UsedForField extends StatefulWidget {
   final DocumentId sightingId;
+  final VoidCallback onUpdate;
 
-  const UsedForField({super.key, required this.sightingId});
+  const UsedForField(
+      {super.key, required this.sightingId, required this.onUpdate});
 
   @override
   State<UsedForField> createState() => _UsedForFieldState();
@@ -54,6 +56,8 @@ class _UsedForFieldState extends State<UsedForField> {
       sleep(const Duration(milliseconds: 100));
     }
 
+    widget.onUpdate();
+
     // Refresh both paginators
     listPaginator.refresh!();
     tagPaginator.refresh!();
@@ -78,6 +82,8 @@ class _UsedForFieldState extends State<UsedForField> {
       isDeleted = (result.data?['document'] == null);
       sleep(const Duration(milliseconds: 150));
     }
+
+    widget.onUpdate();
 
     // Refresh only the list paginator
     listPaginator.refresh!();


### PR DESCRIPTION
This PR makes sure that users directly see newly created or updated data when they return to the previous screen.

The trick is to wait for the pushed screen to return (after a "pop" event) and look up a global dirty flag (`RefreshProvider`) if the user has created or updated something. If they did, we force a re-load and re-render of the widget which might need to display this update.

On top we're waiting until the document got actually materialized on the node before we return back to the "All Sightings" screen.

**Context**

The underlying issue was actually not that we didn't wait enough before data got materialized on the node, but that when calling "pop" on the navigator stack it'll return back to a "cached" state of the widgets. That makes sense for performance reason obviously but we need to force-trigger a refresh to make sure the changes are visible.

There's a way to hook into a "pop" callback from the perspective of the screen which pushed the next view on the stack. We can then trigger a re-render there, how this is done depends a bit on the widget but I've made it work. 

On top I've made it more "lazy", aka, not trigger a re-render _every_ time we return from somewhere (also bad UX, you don't want to unnecessarily jump in scroll position after returning). To understand if something has changed I've introduced a global state provider where we can keep track of "dirty" flags.

**Todo**

- [x] Refresh All Sightings List after creating a new Sighting
- [x] Refresh All Sightings List after updating a Sighting
- [x] Refresh All Species List after changing a Species
- [x] Refresh All Uses + All Local Name Widgets after changing a sighting
- [x] Only refresh when data actually has been changed

Closes: https://github.com/p2panda/meli/issues/19