### PR TITLE
Set `allow_schema_ids` via node config on startup

### DIFF
--- a/packages/app/lib/io/p2panda/node.dart
+++ b/packages/app/lib/io/p2panda/node.dart
@@ -4,6 +4,7 @@ import 'package:app/io/files.dart';
 import 'package:app/io/graphql/queries.dart';
 import 'package:app/io/p2panda/key_pair.dart';
 import 'package:app/io/p2panda/p2panda.dart';
+import 'package:app/models/schema_ids.dart';
 import 'package:app/utils/sleep.dart';
 
 const List<String> relayAddresses = bool.hasEnvironment("RELAY_ADDRESS")
@@ -27,10 +28,12 @@ Future<void> startNode() async {
 
   // Start node in background thread
   p2panda.startNode(
-      keyPair: key,
-      databaseUrl: databaseUrl,
-      blobsBasePath: basePath,
-      relayAddresses: relayAddresses);
+    keyPair: key,
+    databaseUrl: databaseUrl,
+    blobsBasePath: basePath,
+    relayAddresses: relayAddresses,
+    allowSchemaIds: ALL_SCHEMA_IDS,
+  );
 
   // .. since we can't `await` the FFI binding method from Rust we need to
   // poll here to find out until the node is ready

--- a/packages/app/lib/models/schema_ids.dart
+++ b/packages/app/lib/models/schema_ids.dart
@@ -55,6 +55,8 @@ abstract final class SchemaIds {
 const List<SchemaId> ALL_SCHEMA_IDS = [
   SchemaIds.blob,
   SchemaIds.blob_piece,
+  SchemaIds.schema_definition,
+  SchemaIds.schema_field_definition,
   SchemaIds.bee_sighting,
   SchemaIds.bee_local_name,
   SchemaIds.bee_species,

--- a/packages/app/lib/models/schema_ids.dart
+++ b/packages/app/lib/models/schema_ids.dart
@@ -7,6 +7,8 @@ abstract final class SchemaIds {
   /// System schema
   static const SchemaId blob_piece = 'blob_piece_v1';
   static const SchemaId blob = 'blob_v1';
+  static const SchemaId schema_definition = 'schema_definition_v1';
+  static const SchemaId schema_field_definition = 'schema_field_definition_v1';
 
   /// Sighting and species schema.
   static const SchemaId bee_sighting =
@@ -51,6 +53,8 @@ abstract final class SchemaIds {
 
 /// List of all schema ids which are used by the meli app.
 const List<SchemaId> ALL_SCHEMA_IDS = [
+  SchemaIds.blob,
+  SchemaIds.blob_piece,
   SchemaIds.bee_sighting,
   SchemaIds.bee_local_name,
   SchemaIds.bee_species,

--- a/packages/p2panda/lib/src/bridge_generated.dart
+++ b/packages/p2panda/lib/src/bridge_generated.dart
@@ -64,6 +64,7 @@ abstract class P2Panda {
       required String databaseUrl,
       required String blobsBasePath,
       required List<String> relayAddresses,
+      required List<String> allowSchemaIds,
       dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kStartNodeConstMeta;
@@ -334,18 +335,26 @@ class P2PandaImpl implements P2Panda {
       required String databaseUrl,
       required String blobsBasePath,
       required List<String> relayAddresses,
+      required List<String> allowSchemaIds,
       dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_key_pair(keyPair);
     var arg1 = _platform.api2wire_String(databaseUrl);
     var arg2 = _platform.api2wire_String(blobsBasePath);
     var arg3 = _platform.api2wire_StringList(relayAddresses);
+    var arg4 = _platform.api2wire_StringList(allowSchemaIds);
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) =>
-          _platform.inner.wire_start_node(port_, arg0, arg1, arg2, arg3),
+          _platform.inner.wire_start_node(port_, arg0, arg1, arg2, arg3, arg4),
       parseSuccessData: _wire2api_unit,
       parseErrorData: _wire2api_FrbAnyhowException,
       constMeta: kStartNodeConstMeta,
-      argValues: [keyPair, databaseUrl, blobsBasePath, relayAddresses],
+      argValues: [
+        keyPair,
+        databaseUrl,
+        blobsBasePath,
+        relayAddresses,
+        allowSchemaIds
+      ],
       hint: hint,
     ));
   }
@@ -353,7 +362,13 @@ class P2PandaImpl implements P2Panda {
   FlutterRustBridgeTaskConstMeta get kStartNodeConstMeta =>
       const FlutterRustBridgeTaskConstMeta(
         debugName: "start_node",
-        argNames: ["keyPair", "databaseUrl", "blobsBasePath", "relayAddresses"],
+        argNames: [
+          "keyPair",
+          "databaseUrl",
+          "blobsBasePath",
+          "relayAddresses",
+          "allowSchemaIds"
+        ],
       );
 
   Future<void> shutdownNode({dynamic hint}) {
@@ -944,6 +959,7 @@ class P2PandaWire implements FlutterRustBridgeWireBase {
     ffi.Pointer<wire_uint_8_list> database_url,
     ffi.Pointer<wire_uint_8_list> blobs_base_path,
     ffi.Pointer<wire_StringList> relay_addresses,
+    ffi.Pointer<wire_StringList> allow_schema_ids,
   ) {
     return _wire_start_node(
       port_,
@@ -951,6 +967,7 @@ class P2PandaWire implements FlutterRustBridgeWireBase {
       database_url,
       blobs_base_path,
       relay_addresses,
+      allow_schema_ids,
     );
   }
 
@@ -961,6 +978,7 @@ class P2PandaWire implements FlutterRustBridgeWireBase {
               ffi.Pointer<wire_KeyPair>,
               ffi.Pointer<wire_uint_8_list>,
               ffi.Pointer<wire_uint_8_list>,
+              ffi.Pointer<wire_StringList>,
               ffi.Pointer<wire_StringList>)>>('wire_start_node');
   late final _wire_start_node = _wire_start_nodePtr.asFunction<
       void Function(
@@ -968,6 +986,7 @@ class P2PandaWire implements FlutterRustBridgeWireBase {
           ffi.Pointer<wire_KeyPair>,
           ffi.Pointer<wire_uint_8_list>,
           ffi.Pointer<wire_uint_8_list>,
+          ffi.Pointer<wire_StringList>,
           ffi.Pointer<wire_StringList>)>();
 
   void wire_shutdown_node(

--- a/packages/p2panda/native/src/api.rs
+++ b/packages/p2panda/native/src/api.rs
@@ -2,7 +2,7 @@
 
 use android_logger::{Config, FilterBuilder};
 use anyhow::{anyhow, Result};
-use aquadoggo::Configuration;
+use aquadoggo::{AllowList, Configuration};
 use ed25519_dalek::SecretKey;
 use flutter_rust_bridge::RustOpaque;
 use log::LevelFilter;
@@ -14,7 +14,7 @@ pub use p2panda_rs::identity::KeyPair as PandaKeyPair;
 use p2panda_rs::operation;
 use p2panda_rs::operation::traits::{Actionable, Schematic};
 use p2panda_rs::operation::EncodedOperation;
-use p2panda_rs::schema::SchemaId;
+use p2panda_rs::schema::{Schema, SchemaId};
 use tokio::sync::OnceCell;
 
 use crate::node::Manager;
@@ -215,6 +215,7 @@ pub fn start_node(
     database_url: String,
     blobs_base_path: String,
     relay_addresses: Vec<String>,
+    allow_schema_ids: Vec<String>,
 ) -> Result<()> {
     // Initialise logging for Android developer console
     android_logger::init_once(
@@ -233,6 +234,11 @@ pub fn start_node(
     config.blobs_base_path = blobs_base_path.into();
     config.worker_pool_size = 2;
     config.database_max_connections = 16;
+    let allow_schema_ids = allow_schema_ids
+        .iter()
+        .map(|id| SchemaId::new(id))
+        .collect::<Result<Vec<SchemaId>, _>>()?;
+    config.allow_schema_ids = AllowList::Set(allow_schema_ids);
     config.network.mdns = true;
     config.network.relay_addresses = relay_addresses
         .iter()

--- a/packages/p2panda/native/src/api.rs
+++ b/packages/p2panda/native/src/api.rs
@@ -14,7 +14,7 @@ pub use p2panda_rs::identity::KeyPair as PandaKeyPair;
 use p2panda_rs::operation;
 use p2panda_rs::operation::traits::{Actionable, Schematic};
 use p2panda_rs::operation::EncodedOperation;
-use p2panda_rs::schema::{Schema, SchemaId};
+use p2panda_rs::schema::SchemaId;
 use tokio::sync::OnceCell;
 
 use crate::node::Manager;

--- a/packages/p2panda/native/src/bridge_generated.rs
+++ b/packages/p2panda/native/src/bridge_generated.rs
@@ -114,6 +114,7 @@ fn wire_start_node_impl(
     database_url: impl Wire2Api<String> + UnwindSafe,
     blobs_base_path: impl Wire2Api<String> + UnwindSafe,
     relay_addresses: impl Wire2Api<Vec<String>> + UnwindSafe,
+    allow_schema_ids: impl Wire2Api<Vec<String>> + UnwindSafe,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (), _>(
         WrapInfo {
@@ -126,12 +127,14 @@ fn wire_start_node_impl(
             let api_database_url = database_url.wire2api();
             let api_blobs_base_path = blobs_base_path.wire2api();
             let api_relay_addresses = relay_addresses.wire2api();
+            let api_allow_schema_ids = allow_schema_ids.wire2api();
             move |task_callback| {
                 start_node(
                     api_key_pair,
                     api_database_url,
                     api_blobs_base_path,
                     api_relay_addresses,
+                    api_allow_schema_ids,
                 )
             }
         },
@@ -358,6 +361,7 @@ mod io {
         database_url: *mut wire_uint_8_list,
         blobs_base_path: *mut wire_uint_8_list,
         relay_addresses: *mut wire_StringList,
+        allow_schema_ids: *mut wire_StringList,
     ) {
         wire_start_node_impl(
             port_,
@@ -365,6 +369,7 @@ mod io {
             database_url,
             blobs_base_path,
             relay_addresses,
+            allow_schema_ids,
         )
     }
 


### PR DESCRIPTION
The `aquadoggo` node backing our app should only replicate schema required for the meli application. This is now set on node startup.