### PR TITLE
Fix buggy autocomplete behaviours

### DIFF
--- a/packages/app/lib/ui/screens/sighting.dart
+++ b/packages/app/lib/ui/screens/sighting.dart
@@ -104,8 +104,9 @@ class _SightingProfileState extends State<SightingProfile> {
     if (item == null) {
       // Remove local name from sighting
     } else if (item.documentId == null) {
-      // Create new local name to assign it then to sighting
-      localNames.add(await LocalName.create(name: item.value));
+      // Create new local name to assign it then to sighting. This method checks
+      // for existing local names with the same value before
+      localNames.add(await createDeduplicatedLocalName(item.value));
     } else if (item.documentId != null) {
       // Assign existing local name to sighting
       localNames.add(LocalName(

--- a/packages/app/lib/ui/widgets/local_name_autocomplete.dart
+++ b/packages/app/lib/ui/widgets/local_name_autocomplete.dart
@@ -48,16 +48,26 @@ class _LocalNameAutocompleteState extends State<LocalNameAutocomplete> {
             final List<dynamic> documents =
                 result.data![DEFAULT_RESULTS_KEY]['documents'] as List<dynamic>;
 
-            final List<AutocompleteItem> options = documents.map((document) {
+            final List<AutocompleteItem> options = [];
+            Set<String> seen = {};
+
+            for (var document in documents) {
               final localName =
                   LocalName.fromJson(document as Map<String, dynamic>);
-              return AutocompleteItem(
+
+              // De-duplicate results with same "name" value
+              if (seen.contains(localName.name)) {
+                continue;
+              }
+
+              seen.add(localName.name);
+              options.add(AutocompleteItem(
                   value: localName.name,
                   documentId: localName.id,
-                  viewId: localName.viewId);
-            }).toList();
+                  viewId: localName.viewId));
+            }
 
-            return options;
+            return options.toList();
           } catch (error) {
             print(error.toString());
             return [];

--- a/packages/app/lib/ui/widgets/local_name_field.dart
+++ b/packages/app/lib/ui/widgets/local_name_field.dart
@@ -29,19 +29,10 @@ class _LocalNameFieldState extends State<LocalNameField> {
   /// Contains changed value when user adjusted the field.
   AutocompleteItem? _dirty;
 
-  void _submit() async {
-    if (_dirty == null) {
-      // Nothing has changed
-    } else if (_dirty!.value == '') {
-      // Value is empty, we consider the user wants to remove it
-      await widget.onUpdate.call(null);
-    } else {
-      // Value gets updated (either with item from database or something new)
-      await widget.onUpdate.call(_dirty!);
-    }
-
-    // Any time the submit method is triggered we toggle out of edit mode
-    _toggleEditMode();
+  void _toggleEditMode() {
+    setState(() {
+      isEditMode = !isEditMode;
+    });
   }
 
   void _cancel() {
@@ -50,22 +41,23 @@ class _LocalNameFieldState extends State<LocalNameField> {
     });
   }
 
-  void _changeValue(AutocompleteItem newValue) async {
-    if (widget.current == null) {
-      // User selected an item when none was selected before
-      _dirty = newValue;
-    } else if (widget.current!.name != newValue.value) {
-      // User selected a different item than before
-      _dirty = newValue;
-    } else {
-      // User selected the same item or still no item as before .. do nothing!
-    }
+  void _onChanged(AutocompleteItem newValue) {
+    _dirty = newValue;
   }
 
-  void _toggleEditMode() {
-    setState(() {
-      isEditMode = !isEditMode;
-    });
+  void _onSubmit() {
+    if (_dirty == null) {
+      // Nothing has changed
+    } else if (_dirty!.value == '') {
+      // Value is empty, we consider the user wants to remove it
+      widget.onUpdate.call(null);
+    } else {
+      // Value gets updated (either with item from database or something new)
+      widget.onUpdate.call(_dirty!);
+    }
+
+    // Any time the submit method is triggered we toggle out of edit mode
+    _toggleEditMode();
   }
 
   Widget _editableValue() {
@@ -79,7 +71,7 @@ class _LocalNameFieldState extends State<LocalNameField> {
         : null;
 
     return LocalNameAutocomplete(
-        initialValue: initialValue, onSubmit: _submit, onChanged: _changeValue);
+        initialValue: initialValue, onSubmit: _onSubmit, onChanged: _onChanged);
   }
 
   @override
@@ -97,7 +89,7 @@ class _LocalNameFieldState extends State<LocalNameField> {
                     Padding(
                         padding: const EdgeInsets.only(top: 8.0),
                         child: ActionButtons(
-                          onAction: _submit,
+                          onAction: _onSubmit,
                           onCancel: _cancel,
                         ))
                   ]

--- a/packages/app/lib/ui/widgets/species_field.dart
+++ b/packages/app/lib/ui/widgets/species_field.dart
@@ -168,7 +168,8 @@ class _SpeciesFieldState extends State<SpeciesField> {
     for (final (index, item) in _taxonomy.reversed.indexed) {
       final rank = _taxonomySettings[_taxonomy.length - index - 1];
       if (item!.documentId == null) {
-        final id = await createTaxon(rank['schemaId']!,
+        // This method checks if a duplicate with similar values already exists
+        final id = await createDeduplicatedTaxon(rank['schemaId']!,
             name: item.value, parentId: parent?.documentId);
         parent =
             AutocompleteItem(value: item.value, documentId: id, viewId: id);

--- a/packages/app/lib/ui/widgets/taxonomy_autocomplete.dart
+++ b/packages/app/lib/ui/widgets/taxonomy_autocomplete.dart
@@ -48,16 +48,26 @@ class _TaxonomyAutocompleteState extends State<TaxonomyAutocomplete> {
             final List<dynamic> documents =
                 result.data![DEFAULT_RESULTS_KEY]['documents'] as List<dynamic>;
 
-            final List<AutocompleteItem> options = documents.map((document) {
-              final result = BaseTaxonomy.fromJson(
-                  widget.schemaId, document as Map<String, dynamic>);
-              return AutocompleteItem(
-                  value: result.name,
-                  documentId: result.id,
-                  viewId: result.viewId);
-            }).toList();
+            final List<AutocompleteItem> options = [];
+            Set<String> seen = {};
 
-            return options;
+            for (var document in documents) {
+              final localName = BaseTaxonomy.fromJson(
+                  widget.schemaId, document as Map<String, dynamic>);
+
+              // De-duplicate results with same "name" value
+              if (seen.contains(localName.name)) {
+                continue;
+              }
+
+              seen.add(localName.name);
+              options.add(AutocompleteItem(
+                  value: localName.name,
+                  documentId: localName.id,
+                  viewId: localName.viewId));
+            }
+
+            return options.toList();
           } catch (error) {
             print(error.toString());
             return [];


### PR DESCRIPTION
- Fix autocomplete selecting first value on pressing Enter by removing `onFieldSubmitted` argument in `Autocomplete` widget
- Fix issue when manually entering string it only saved the one from the previous key stroke
- Add logic to de-duplicate autocomplete options for "Local Name" and "Taxon" widgets
- Add logic to check for already existing items when creating new "Local Name" or "Taxon" data

Closes #39 and #40 