### PR TITLE
Improve autocomplete UX

### DIFF
--- a/packages/app/lib/ui/widgets/autocomplete.dart
+++ b/packages/app/lib/ui/widgets/autocomplete.dart
@@ -210,15 +210,7 @@ class _MeliAutocompleteState extends State<MeliAutocomplete> {
           // even when we're currently querying for new ones
           _lastOptions = options;
 
-          // Do not show user input if it is the same value as an option
-          final duplicates = options
-              .where((element) => element.value == textEditingValue.text);
-
-          // Include what the user is currently typing to make this an selectable
-          // "free form" option
-          return textEditingValue.text.isNotEmpty && duplicates.isEmpty
-              ? [AutocompleteItem(value: textEditingValue.text), ...options]
-              : options;
+          return options;
         },
         onSelected: (AutocompleteItem selection) {
           if (widget.onChanged != null) {

--- a/packages/app/lib/ui/widgets/autocomplete.dart
+++ b/packages/app/lib/ui/widgets/autocomplete.dart
@@ -103,7 +103,14 @@ class _MeliAutocompleteState extends State<MeliAutocomplete> {
   }
 
   void _onChanged(String value) {
-    if (widget.onChanged != null) {
+    // Double-check if user actually typed _exactly_ the same value
+    // as one of our existing options
+    final Iterable<AutocompleteItem> duplicates = _lastOptions.where(
+        (element) => element.value == value && element.documentId != null);
+    if (duplicates.isNotEmpty) {
+      widget.onChanged!.call(duplicates.first);
+    } else {
+      // .. otherwise use newly created user value
       widget.onChanged!.call(AutocompleteItem(value: value));
     }
   }
@@ -224,7 +231,11 @@ class _MeliAutocompleteState extends State<MeliAutocomplete> {
           // even when we're currently querying for new ones
           _lastOptions = options;
 
-          return options;
+          // Remove option if it is the same as initial value
+          final filtered = options
+              .where((element) => element.value != widget.initialValue?.value);
+
+          return filtered;
         },
         onSelected: (AutocompleteItem selection) {
           // Unfocus text field when user clicked on an option, this will hide


### PR DESCRIPTION
This hopefully reduces confusion of some users trying to work with the autocomplete menu.

- Doesn't show the currently typed value as an autocomplete option (this will now show no options at all if user types in an unknown value)
- Doesn't show an option if it is the same as the currently persisted one (initial value)
- Bring back logic to automatically select from existing options when user typed in exactly the same value
- Blurs focus of the text input element (hiding the keyboard) as soon as an item got selected or submit

Closes #121 