### PR TITLE
Account for null taxonomies in species

### DIFF
--- a/packages/app/lib/models/species.dart
+++ b/packages/app/lib/models/species.dart
@@ -14,7 +14,7 @@ class Species {
   final DocumentId id;
   DocumentViewId viewId;
 
-  TaxonomySpecies species;
+  TaxonomySpecies? species;
   String description;
 
   Species(
@@ -27,8 +27,10 @@ class Species {
     return Species(
         id: result['meta']['documentId'] as DocumentId,
         viewId: result['meta']['viewId'] as DocumentViewId,
-        species: TaxonomySpecies.fromJson(
-            result['fields']['species'] as Map<String, dynamic>),
+        species: result['fields']['species'] != null
+            ? TaxonomySpecies.fromJson(
+                result['fields']['species'] as Map<String, dynamic>)
+            : null,
         description: result['fields']['description'] as String);
   }
 
@@ -68,8 +70,10 @@ class Species {
   }
 
   Future<void> delete() async {
-    // Delete the taxonomy_species document this species relates to first
-    await species.delete();
+    if (species != null) {
+      // Delete the taxonomy_species document this species relates to first
+      await species!.delete();
+    }
     // Then delete the bee_species document
     await deleteSpecies(viewId);
   }

--- a/packages/app/lib/ui/screens/sighting.dart
+++ b/packages/app/lib/ui/screens/sighting.dart
@@ -129,7 +129,7 @@ class _SightingProfileState extends State<SightingProfile> {
   }
 
   Future<void> _updateSpecies(TaxonomySpecies? taxon) async {
-    if (sighting.species?.species.id == taxon?.id) {
+    if (sighting.species?.species?.id == taxon?.id) {
       // Nothing has changed
       return;
     }
@@ -199,8 +199,8 @@ class SightingProfileTitle extends StatelessWidget {
   Widget build(BuildContext context) {
     List<String> title = [];
 
-    if (sighting.species != null) {
-      title.add(sighting.species!.species.name);
+    if (sighting.species != null && sighting.species!.species != null) {
+      title.add(sighting.species!.species!.name);
     }
 
     if (sighting.localName != null) {

--- a/packages/app/lib/ui/screens/species.dart
+++ b/packages/app/lib/ui/screens/species.dart
@@ -103,7 +103,7 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
   }
 
   Future<void> _updateTaxon(TaxonomySpecies? taxon) async {
-    if (species.species.id == taxon?.id) {
+    if (species.species?.id == taxon?.id) {
       // Nothing has changed
       return;
     } else if (taxon != null) {
@@ -120,6 +120,8 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
+
     return Container(
       padding: const EdgeInsets.only(top: 0.0, right: 20.0, left: 20.0),
       decoration: const SeaWavesBackground(),
@@ -127,7 +129,9 @@ class _SpeciesProfileState extends State<SpeciesProfile> {
         slivers: [
           SliverList(
               delegate: SliverChildListDelegate([
-            SpeciesProfileTitle(species.species.name),
+            SpeciesProfileTitle(species.species != null
+                ? species.species!.name
+                : t.sightingUnspecified),
             const SizedBox(height: 100.0),
             SpeciesField(
               species.species,

--- a/packages/app/lib/ui/widgets/sighting_card.dart
+++ b/packages/app/lib/ui/widgets/sighting_card.dart
@@ -36,8 +36,8 @@ class _SightingCardState extends State<SightingCard> {
   Widget get _title {
     String title = AppLocalizations.of(context)!.sightingUnspecified;
 
-    if (widget.species != null) {
-      title = widget.species!.species.name;
+    if (widget.species != null && widget.species!.species != null) {
+      title = widget.species!.species!.name;
     } else if (widget.localName != null) {
       title = widget.localName!.name;
     }

--- a/packages/app/lib/ui/widgets/species_card.dart
+++ b/packages/app/lib/ui/widgets/species_card.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'package:app/io/p2panda/publish.dart';
@@ -13,7 +14,7 @@ import 'package:app/ui/widgets/image.dart';
 
 class SpeciesCard extends StatefulWidget {
   final DocumentId id;
-  final TaxonomySpecies taxonomySpecies;
+  final TaxonomySpecies? taxonomySpecies;
 
   final VoidCallback onTap;
 
@@ -30,9 +31,13 @@ class SpeciesCard extends StatefulWidget {
 class _SpeciesCardState extends State<SpeciesCard> {
   bool isSelected = false;
 
-  Widget get _title {
+  Widget _title(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
+
     return Text(
-      widget.taxonomySpecies.name,
+      widget.taxonomySpecies != null
+          ? widget.taxonomySpecies!.name
+          : t.sightingUnspecified,
       textAlign: TextAlign.center,
       overflow: TextOverflow.ellipsis,
       style: const TextStyle(
@@ -111,7 +116,7 @@ class _SpeciesCardState extends State<SpeciesCard> {
               padding: const EdgeInsets.only(
                   top: 8.0, right: 6.0, bottom: 10.0, left: 6.0),
               alignment: AlignmentDirectional.center,
-              child: _title,
+              child: _title(context),
             ),
           ])),
     );


### PR DESCRIPTION
We never expect `TaxonomySpecies` to be null for `Species` but in case of data corruption this can still happen.

Even though this is an edge case we don't want the app to crash here.