### PR TITLE
chore: update minimum rust version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ providing all p2panda functionality via FFI bindings.
 
 > ⚠️ The _exact_ NDK version _is required_.
 
-* [Rust](https://www.rust-lang.org/tools/install) `1.74.0`
+* [Rust](https://www.rust-lang.org/tools/install) `1.75.0`
 * [Java](https://dev.java/) `17`
 * [Android SDK](https://developer.android.com/tools) `34.0.0`
 * [Android NDK](https://developer.android.com/ndk/) `25.2.9519653`


### PR DESCRIPTION
Had mine pinned to 1.74 but that prevented me from building the rust stuff:

```sh
2024/06/28 09:15:11 [INFO] Running cargo expand in '/Users/andrewchou/GitHub/p2panda/meli/packages/p2panda/native'
2024/06/28 09:15:12 [WARN] command=cd "/Users/andrewchou/GitHub/p2panda/meli/packages/p2panda/native" && "cargo" "expand" "--theme=none" "--ugly" stdout= stderr=error: package `libp2p-identify v0.44.2` cannot be built because it requires rustc 1.75.0 or newer, while the currently active rustc version is 1.74.1
Either upgrade to rustc 1.75.0 or newer, or use
cargo update libp2p-identify@0.44.2 --precise ver
where `ver` is the latest version of `libp2p-identify` supporting rustc 1.74.1
```