### PR TITLE
fix: upgrade rust version for build-android workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: moonrepo/setup-rust@v1
         with:
-          channel: "1.74"
+          channel: "1.75"
           components: rustfmt
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
follow-up to #157 